### PR TITLE
[FEAT] Add HTTP/2 support

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches: [ main ]
   workflow_dispatch:
+  workflow_call:
 
 jobs:
 

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
 
-  test:
+  integrationtest:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install the requirements
         run: pip install -r requirements.txt
 
-      - name: Execute the integrationtests
+      - name: Execute the integrationtests (http1.1)
         run: python3 --version && python3 -m unittest discover tests/integrationtest
         env:
           GRAFANA_HOST: ${{ secrets.GRAFANA_HOST }}
@@ -29,3 +29,15 @@ jobs:
           GRAFANA_DASHBOARD_NAME: ${{ secrets.GRAFANA_DASHBOARD_NAME }}
           GRAFANA_USERNAME: ${{ secrets.GRAFANA_USERNAME }}
           GRAFANA_PASSWORD: ${{ secrets.GRAFANA_PASSWORD }}
+          HTTP2: "False"
+
+      - name: Execute the integrationtests (http2)
+        run: python3 --version && python3 -m unittest discover tests/integrationtest
+        env:
+          GRAFANA_HOST: ${{ secrets.GRAFANA_HOST }}
+          GRAFANA_TOKEN: ${{ secrets.GRAFANA_TOKEN }}
+          GRAFANA_DASHBOARD_PATH: ${{ secrets.GRAFANA_DASHBOARD_PATH }}
+          GRAFANA_DASHBOARD_NAME: ${{ secrets.GRAFANA_DASHBOARD_NAME }}
+          GRAFANA_USERNAME: ${{ secrets.GRAFANA_USERNAME }}
+          GRAFANA_PASSWORD: ${{ secrets.GRAFANA_PASSWORD }}
+          HTTP2: "True"

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -5,23 +5,31 @@ on:
     - cron: '0 22 * * 1'
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
   workflow_dispatch:
 
 jobs:
 
-  integrationtest:
+  grafana-api-sdk-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.10' ]
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+          cache: 'pip'
 
       - name: Install the requirements
         run: pip install -r requirements.txt
 
       - name: Execute the integrationtests (http1.1)
-        run: python3 --version && python3 -m unittest discover tests/integrationtest
+        run: python3 -m unittest discover tests/integrationtest
         env:
           GRAFANA_HOST: ${{ secrets.GRAFANA_HOST }}
           GRAFANA_TOKEN: ${{ secrets.GRAFANA_TOKEN }}
@@ -32,7 +40,7 @@ jobs:
           HTTP2: "False"
 
       - name: Execute the integrationtests (http2)
-        run: python3 --version && python3 -m unittest discover tests/integrationtest
+        run: python3 -m unittest discover tests/integrationtest
         env:
           GRAFANA_HOST: ${{ secrets.GRAFANA_HOST }}
           GRAFANA_TOKEN: ${{ secrets.GRAFANA_TOKEN }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -24,7 +24,7 @@ jobs:
           cache: 'pip'
 
       - name: Install the requirements
-        run: pip install -r requirements.txt
+        run: pip install -r requirements.txt && pip install setuptools~=65.5.1
 
       - name: Install pypa/build
         run: >-

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -157,6 +157,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.head_ref }}
 
-  pr-validation:
+  pr-integrationtest:
     uses: ./.github/workflows/integrationtest.yml
     secrets: inherit

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -174,11 +174,15 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.head_ref }}
 
-      - name: Verify Documentation
-        id: verify-documentation
-        run: echo "result=true" >> "$GITHUB_OUTPUT"
+      - name: "test"
+        env:
+          OUTPUT1: ${{needs.pr-test.outputs.run_integration_test}}
+          OUTPUT2: ${{needs.pr-lint.outputs.run_integration_test}}
+          OUTPUT3: ${{needs.pr-coverage.outputs.run_integration_test}}
+          OUTPUT4: ${{needs.pr-documentation.outputs.run_integration_test}}
+        run: echo "$OUTPUT1 $OUTPUT2 $OUTPUT3 $OUTPUT4"
 
-  validation:
+  pr-validation:
     if: needs.pr-test.outputs.run_integration_test == 'true' && needs.pr-lint.outputs.run_integration_test == 'true' && needs.pr-coverage.outputs.run_integration_test == 'true' && needs.pr-documentation.outputs.run_integration_test == 'true'
     uses: ./.github/workflows/integrationtest.yml
     secrets: inherit

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -11,8 +11,6 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.10' ]
-    outputs:
-      run_integration_test: ${{ steps.verify-unittest.outputs.result }}
 
     steps:
       - uses: actions/checkout@v3
@@ -30,17 +28,11 @@ jobs:
       - name: Execute the unittests
         run: python3 -m unittest discover tests/unittests
 
-      - name: Verify Test
-        id: verify-unittest
-        run: echo "result=true" >> "$GITHUB_OUTPUT"
-
   pr-lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [ '3.10' ]
-    outputs:
-      run_integration_test: ${{ steps.verify-lint.outputs.result }}
 
     steps:
       - uses: actions/checkout@v3
@@ -59,17 +51,11 @@ jobs:
           flake8_args: --config=.flake8
           fail_on_error: true
 
-      - name: Verify Lint
-        id: verify-lint
-        run: echo "result=true" >> "$GITHUB_OUTPUT"
-
   pr-coverage:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [ '3.10' ]
-    outputs:
-      run_integration_test: ${{ steps.verifyCoverage.outputs.result }}
 
     steps:
       - uses: actions/checkout@v3
@@ -124,17 +110,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.head_ref }}
 
-      - name: Verify Coverage
-        id: verifyCoverage
-        run: echo "result=true" >> "$GITHUB_OUTPUT"
-
   pr-documentation:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [ '3.9' ]
-    outputs:
-      run_integration_test: ${{ steps.verify-documentation.outputs.result }}
 
     steps:
       - uses: actions/checkout@v3
@@ -177,19 +157,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.head_ref }}
 
-      - name: Verify Documentation
-        id: verify-documentation
-        run: echo "result=true" >> "$GITHUB_OUTPUT"
-
-      - name: "test"
-        env:
-          OUTPUT1: ${{needs.pr-test.outputs.run_integration_test}}
-          OUTPUT2: ${{needs.pr-lint.outputs.run_integration_test}}
-          OUTPUT3: ${{needs.pr-coverage.outputs.run_integration_test}}
-          OUTPUT4: ${{needs.pr-documentation.outputs.run_integration_test}}
-        run: echo "$OUTPUT1 $OUTPUT2 $OUTPUT3 $OUTPUT4" && echo "${{ steps.verify-documentation.outputs.result }}"
-
   pr-validation:
-    if: needs.pr-test.outputs.run_integration_test == 'true' && needs.pr-lint.outputs.run_integration_test == 'true' && needs.pr-coverage.outputs.run_integration_test == 'true' && needs.pr-documentation.outputs.run_integration_test == 'true'
     uses: ./.github/workflows/integrationtest.yml
     secrets: inherit

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -69,7 +69,7 @@ jobs:
       matrix:
         python-version: [ '3.10' ]
     outputs:
-      run_integration_test: ${{ steps.verify-coverage.outputs.result }}
+      run_integration_test: ${{ steps.verifyCoverage.outputs.result }}
 
     steps:
       - uses: actions/checkout@v3
@@ -125,7 +125,7 @@ jobs:
           branch: ${{ github.head_ref }}
 
       - name: Verify Coverage
-        id: verify-coverage
+        id: verifyCoverage
         run: echo "result=true" >> "$GITHUB_OUTPUT"
 
   pr-documentation:

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -28,8 +28,11 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Execute the unittests
+        run: python3 -m unittest discover tests/unittests
+
+      - name: Verify Test
         id: verify-unittest
-        run: python3 -m unittest discover tests/unittests && echo "result=true" >> "$GITHUB_OUTPUT"
+        run: echo "result=true" >> "$GITHUB_OUTPUT"
 
   pr-lint:
     runs-on: ubuntu-latest
@@ -56,7 +59,7 @@ jobs:
           flake8_args: --config=.flake8
           fail_on_error: true
 
-      - name: Verify lint
+      - name: Verify Lint
         id: verify-lint
         run: echo "result=true" >> "$GITHUB_OUTPUT"
 
@@ -174,13 +177,17 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.head_ref }}
 
+      - name: Verify Documentation
+        id: verify-documentation
+        run: echo "result=true" >> "$GITHUB_OUTPUT"
+
       - name: "test"
         env:
           OUTPUT1: ${{needs.pr-test.outputs.run_integration_test}}
           OUTPUT2: ${{needs.pr-lint.outputs.run_integration_test}}
           OUTPUT3: ${{needs.pr-coverage.outputs.run_integration_test}}
           OUTPUT4: ${{needs.pr-documentation.outputs.run_integration_test}}
-        run: echo "$OUTPUT1 $OUTPUT2 $OUTPUT3 $OUTPUT4"
+        run: echo "$OUTPUT1 $OUTPUT2 $OUTPUT3 $OUTPUT4" && echo "${{ steps.verify-documentation.outputs.result }}"
 
   pr-validation:
     if: needs.pr-test.outputs.run_integration_test == 'true' && needs.pr-lint.outputs.run_integration_test == 'true' && needs.pr-coverage.outputs.run_integration_test == 'true' && needs.pr-documentation.outputs.run_integration_test == 'true'

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -6,11 +6,11 @@ on:
 
 jobs:
 
-  test:
+  pr-test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.x' ]
+        python-version: [ '3.10' ]
 
     steps:
       - uses: actions/checkout@v3
@@ -28,11 +28,11 @@ jobs:
       - name: Execute the unittests
         run: python3 -m unittest discover tests/unittests
 
-  lint:
+  pr-lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.x' ]
+        python-version: [ '3.10' ]
 
     steps:
       - uses: actions/checkout@v3
@@ -54,11 +54,11 @@ jobs:
           flake8_args: --config=.flake8
           fail_on_error: true
 
-  coverage:
+  pr-coverage:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.x' ]
+        python-version: [ '3.10' ]
 
     steps:
       - uses: actions/checkout@v3
@@ -113,11 +113,11 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.head_ref }}
 
-  documentation:
+  pr-documentation:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.9' ]
+        python-version: [ '3.10' ]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           flake8_args: --config=.flake8
+          fail_on_error: true
 
   coverage:
     runs-on: ubuntu-latest
@@ -81,14 +82,58 @@ jobs:
       - name: Execute the coverage checks
         uses: MishaKav/pytest-coverage-comment@v1.1.47
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           pytest-coverage-path: ./pytest-coverage.txt
           junitxml-path: ./pytest.xml
           hide-badge: true
-          create-new-commit: true
+          create-new-comment: false
 
       - name: Generate coverage badge
         run: coverage-badge -f -o docs/coverage.svg
+
+      - name: Check changed files
+        uses: tj-actions/verify-changed-files@v16
+        id: verify-changed-files
+        with:
+          files: |
+            docs
+
+      - name: Commit files
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add --force docs
+          git commit -m "docs: Add coverage badge"
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.head_ref }}
+
+  documentation:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.9' ]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+          cache: 'pip'
+
+      - name: Install the requirements
+        run: pip install pydoc-markdown==4.6.3 mkdocs mkdocs-material
 
       - name: Generate documentation
         run: pydoc-markdown --render-toc && rm -rf docs/content && mv build/docs/* docs
@@ -106,7 +151,7 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add --force docs
-          git commit -m "docs: Add coverage badge and documentation"
+          git commit -m "docs: Add the documentation"
 
       - name: Push changes
         uses: ad-m/github-push-action@master

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.10' ]
+        python-version: [ '3.9' ]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -11,6 +11,8 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.10' ]
+    outputs:
+      run_integration_test: ${{ steps.verify-unittest.outputs.result }}
 
     steps:
       - uses: actions/checkout@v3
@@ -26,13 +28,16 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Execute the unittests
-        run: python3 -m unittest discover tests/unittests
+        id: verify-unittest
+        run: python3 -m unittest discover tests/unittests && echo "result=true" >> "$GITHUB_OUTPUT"
 
   pr-lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [ '3.10' ]
+    outputs:
+      run_integration_test: ${{ steps.verify-lint.outputs.result }}
 
     steps:
       - uses: actions/checkout@v3
@@ -44,21 +49,24 @@ jobs:
           architecture: x64
           cache: 'pip'
 
-      - name: Install the requirements
-        run: pip install -r requirements.txt
-
       - name: Execute the linting checks
-        uses: reviewdog/action-flake8@v3.7.0
+        uses: reviewdog/action-flake8@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           flake8_args: --config=.flake8
           fail_on_error: true
+
+      - name: Verify lint
+        id: verify-lint
+        run: echo "result=true" >> "$GITHUB_OUTPUT"
 
   pr-coverage:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [ '3.10' ]
+    outputs:
+      run_integration_test: ${{ steps.verify-coverage.outputs.result }}
 
     steps:
       - uses: actions/checkout@v3
@@ -113,11 +121,17 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.head_ref }}
 
+      - name: Verify Coverage
+        id: verify-coverage
+        run: echo "result=true" >> "$GITHUB_OUTPUT"
+
   pr-documentation:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [ '3.9' ]
+    outputs:
+      run_integration_test: ${{ steps.verify-documentation.outputs.result }}
 
     steps:
       - uses: actions/checkout@v3
@@ -159,3 +173,12 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.head_ref }}
+
+      - name: Verify Documentation
+        id: verify-documentation
+        run: echo "result=true" >> "$GITHUB_OUTPUT"
+
+  validation:
+    if: needs.pr-test.outputs.run_integration_test == 'true' && needs.pr-lint.outputs.run_integration_test == 'true' && needs.pr-coverage.outputs.run_integration_test == 'true' && needs.pr-documentation.outputs.run_integration_test == 'true'
+    uses: ./.github/workflows/integrationtest.yml
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Grafana API SDK ![Coverage report](https://github.com/ZPascal/grafana_api_sdk/blob/main/docs/coverage.svg)
-The repository includes a Python SDK for the Grafana API. It's possible to communicate with the Grafana API endpoints. Another feature of the SDK is the possibility to specify the used folder for the dashboard.
+The repository includes an SDK for the Grafana API. It's possible to interact with all public available Grafana HTTP API endpoints.
 
 ## Differences between [grafana-client](https://github.com/panodata/grafana-client), [grafana_api](https://github.com/m0nhawk/grafana_api/) and the [grafana_api_sdk](https://github.com/ZPascal/grafana_api_sdk)
 The grafana-client is only a fork of the non-maintained grafana_api repository. In general, the grafana-client project started at the same time, as I started this project. The corresponding SDK is a completely new project and based on non-other project and include a few features that are currently not implemented inside the grafana-client.
 
-The main feature that is implemented inside this library:
+The core features that are implemented inside this library:
 
-- Grafana V8 Alerting API support (possibility to communicate (currently read only) with the attached Prometheus and Alertmanager)
+- All public Grafana API (HTTP) endpoints are supported
+- Full API support for Grafana legacy alerting, current alerting, alerting channels and alert provisioning
+- Possibility to specify custom and self-signed certificates
+- HTTP/2 support
 
 In general my focus inside this project is to implement and deliver old and new features from the Grafana API, to document all features and functionality clear and to increase the overall test coverage of the project.
 
@@ -230,6 +233,7 @@ In general my focus inside this project is to implement and deliver old and new 
 - Renew login session 
 - Get health status
 - Get metrics
+- Get Plugin metrics
 
 ### Licensing
 - Check license availability

--- a/docs/content/grafana_api/api.md
+++ b/docs/content/grafana_api/api.md
@@ -3,6 +3,8 @@
 * [api](#api)
   * [Api](#api.Api)
     * [call\_the\_api](#api.Api.call_the_api)
+    * [prepare\_api\_string](#api.Api.prepare_api_string)
+    * [create\_the\_http\_api\_client](#api.Api.create_the_http_api_client)
 
 <a id="api"></a>
 
@@ -60,4 +62,44 @@ The method execute a defined API call against the Grafana endpoints
 **Returns**:
 
 - `api_call` _any_ - Returns the value of the api call
+
+<a id="api.Api.prepare_api_string"></a>
+
+#### prepare\_api\_string
+
+```python
+@staticmethod
+def prepare_api_string(query_string: str) -> str
+```
+
+The method includes a functionality to prepare the api string for the queries
+
+**Arguments**:
+
+- `query_string` _str_ - Specify the corresponding query string
+  
+
+**Returns**:
+
+- `query_string` _str_ - Returns the adjusted query string
+
+<a id="api.Api.create_the_http_api_client"></a>
+
+#### create\_the\_http\_api\_client
+
+```python
+def create_the_http_api_client(
+        headers: dict = None) -> Union[httpx.Client, httpx.AsyncClient]
+```
+
+The method includes a functionality to create the corresponding HTTP client
+
+**Arguments**:
+
+- `headers` _dict_ - Specify the optional inserted headers (Default None)
+  
+
+**Returns**:
+
+- `client` _Union[httpx.Client, httpx.AsyncClient]_ - Returns the corresponding client
 

--- a/docs/content/grafana_api/model.md
+++ b/docs/content/grafana_api/model.md
@@ -79,6 +79,7 @@ The class includes all necessary variables to establish a connection to the Graf
 - `username` _str_ - Specify the username of the Grafana system
 - `password` _str_ - Specify the password of the Grafana system
 - `timeout` _float_ - Specify the timeout of the Grafana system
+- `http2_support` _bool_ - Specify if you want to use HTTP/2
 - `ssl_context` _ssl.SSLContext_ - Specify the custom ssl context of the Grafana system
 - `num_pools` _int_ - Specify the number of the connection pool
 - `retries` _any_ - Specify the number of the retries. Please use False as parameter to disable the retries

--- a/docs/content/grafana_api/other-http.md
+++ b/docs/content/grafana_api/other-http.md
@@ -6,6 +6,7 @@
     * [renew\_login\_session\_based\_on\_remember\_cookie](#other_http.OtherHTTP.renew_login_session_based_on_remember_cookie)
     * [get\_health\_status](#other_http.OtherHTTP.get_health_status)
     * [get\_metrics](#other_http.OtherHTTP.get_metrics)
+    * [get\_plugin\_metrics](#other_http.OtherHTTP.get_plugin_metrics)
 
 <a id="other_http"></a>
 
@@ -92,13 +93,49 @@ The method includes a functionality to get the health information
 #### get\_metrics
 
 ```python
-def get_metrics() -> str
+def get_metrics(basic_auth_username: str = None,
+                basic_auth_password: str = None) -> str
 ```
 
 The method includes a functionality to get the Grafana metrics information
 
+**Arguments**:
+
+- `basic_auth_username` _str_ - Specify the optional basic auth username
+- `basic_auth_password` _str_ - Specify the optional basic auth password
+  
+
 **Raises**:
 
+- `Exception` - Unspecified error by executing the API call
+  
+
+**Returns**:
+
+- `api_call` _str_ - Returns the metrics information
+
+<a id="other_http.OtherHTTP.get_plugin_metrics"></a>
+
+#### get\_plugin\_metrics
+
+```python
+def get_plugin_metrics(plugin_id: str,
+                       basic_auth_username: str = None,
+                       basic_auth_password: str = None) -> str
+```
+
+The method includes a functionality to get the Grafana plugin metrics information
+
+**Arguments**:
+
+- `plugin_id` _str_ - Specify the plugin id
+- `basic_auth_username` _str_ - Specify the optional basic auth username
+- `basic_auth_password` _str_ - Specify the optional basic auth password
+  
+
+**Raises**:
+
+- `ValueError` - Missed specifying a necessary value
 - `Exception` - Unspecified error by executing the API call
   
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,5 +1,12 @@
 # Grafana API SDK
-The repository includes an SDK for the Grafana API. It's possible to communicate with the Grafana API endpoints. Another feature of the SDK is the possibility to specify the used folder for the dashboard.
+The repository includes an SDK for the Grafana API. It's possible to interact with all public available Grafana HTTP API endpoints.
+
+The core features that are implemented inside this SDK:
+
+- All public Grafana API (HTTP) endpoints are supported
+- Full API support for Grafana legacy alerting, current alerting, alerting channels and alert provisioning
+- Possibility to specify custom and self-signed certificates
+- HTTP/2 support
 
 ## Supported Features
 
@@ -58,7 +65,7 @@ with open("/tmp/test/test.json") as file:
 dashboard.create_or_update_dashboard(message="Create a new test dashboard", dashboard_json=json_dashboard, dashboard_path="test")
 ```
 
-## TLS/ mTLS
+## TLS/ mTLS for HTTP/1.1
 
 It is possible to pass a custom ssl_context to the underlying library to perform the requests to the HTTP API. For this step and to support custom TLS/ mTLS, there is an option to inject the Python ssl_context. More information can be found [here](https://docs.python.org/3/library/ssl.html#ssl.create_default_context) and a dummy TLS/ mTLS implementation below.
 
@@ -90,7 +97,42 @@ ssl_ctx = ssl.create_default_context(
     cafile="/test/path/ca.crt",
 )
 ssl_ctx.verify_mode = ssl.CERT_REQUIRED
-ssl_ctx.load_cert_chain(certfile="/test/path/client.crt", keyfile="/test/path/client.key",)
+ssl_ctx.load_cert_chain(certfile="/test/path/client.crt", keyfile="/test/path/client.key")
+
+model: APIModel = APIModel(host="test", token="test", ssl_context=ssl_ctx)
+```
+
+## TLS/ mTLS for HTTP/2
+
+It is possible to pass a custom HTTP/2 conform ssl_context to the underlying library to perform the requests to the HTTP API. For this step and to support custom TLS/ mTLS, there is an option to create the ssl_context by the execution of `httpx.create_ssl_context()` function. More information can be found [here](https://github.com/encode/httpx/blob/e99e2948e64fac2ca498865e9742ff50a69a2155/httpx/_config.py#L46) and a dummy TLS/ mTLS implementation below.
+
+### TLS
+
+```python
+import httpx
+
+from grafana_api.model import APIModel
+
+ssl_ctx = httpx.create_ssl_context(
+    verify="/test/path/ca.crt",
+    http2=True,
+)
+
+model: APIModel = APIModel(host="test", token="test", ssl_context=ssl_ctx)
+```
+
+### mTLS
+
+```python
+import httpx
+
+from grafana_api.model import APIModel
+
+ssl_ctx = httpx.create_ssl_context(
+    cert=("/test/path/client.crt", "/test/path/client.key"),
+    verify="/test/path/ca.crt",
+    http2=True,
+)
 
 model: APIModel = APIModel(host="test", token="test", ssl_context=ssl_ctx)
 ```

--- a/docs/grafana_api_sdk.md
+++ b/docs/grafana_api_sdk.md
@@ -1,5 +1,12 @@
 # Grafana API SDK
-The repository includes an SDK for the Grafana API. It's possible to communicate with the Grafana API endpoints. Another feature of the SDK is the possibility to specify the used folder for the dashboard.
+The repository includes an SDK for the Grafana API. It's possible to interact with all public available Grafana HTTP API endpoints.
+
+The core features that are implemented inside this SDK:
+
+- All public Grafana API (HTTP) endpoints are supported
+- Full API support for Grafana legacy alerting, current alerting, alerting channels and alert provisioning
+- Possibility to specify custom and self-signed certificates
+- HTTP/2 support
 
 ## Supported Features
 
@@ -58,7 +65,7 @@ with open("/tmp/test/test.json") as file:
 dashboard.create_or_update_dashboard(message="Create a new test dashboard", dashboard_json=json_dashboard, dashboard_path="test")
 ```
 
-## TLS/ mTLS
+## TLS/ mTLS for HTTP/1.1
 
 It is possible to pass a custom ssl_context to the underlying library to perform the requests to the HTTP API. For this step and to support custom TLS/ mTLS, there is an option to inject the Python ssl_context. More information can be found [here](https://docs.python.org/3/library/ssl.html#ssl.create_default_context) and a dummy TLS/ mTLS implementation below.
 
@@ -90,7 +97,42 @@ ssl_ctx = ssl.create_default_context(
     cafile="/test/path/ca.crt",
 )
 ssl_ctx.verify_mode = ssl.CERT_REQUIRED
-ssl_ctx.load_cert_chain(certfile="/test/path/client.crt", keyfile="/test/path/client.key",)
+ssl_ctx.load_cert_chain(certfile="/test/path/client.crt", keyfile="/test/path/client.key")
+
+model: APIModel = APIModel(host="test", token="test", ssl_context=ssl_ctx)
+```
+
+## TLS/ mTLS for HTTP/2
+
+It is possible to pass a custom HTTP/2 conform ssl_context to the underlying library to perform the requests to the HTTP API. For this step and to support custom TLS/ mTLS, there is an option to create the ssl_context by the execution of `httpx.create_ssl_context()` function. More information can be found [here](https://github.com/encode/httpx/blob/e99e2948e64fac2ca498865e9742ff50a69a2155/httpx/_config.py#L46) and a dummy TLS/ mTLS implementation below.
+
+### TLS
+
+```python
+import httpx
+
+from grafana_api.model import APIModel
+
+ssl_ctx = httpx.create_ssl_context(
+    verify="/test/path/ca.crt",
+    http2=True,
+)
+
+model: APIModel = APIModel(host="test", token="test", ssl_context=ssl_ctx)
+```
+
+### mTLS
+
+```python
+import httpx
+
+from grafana_api.model import APIModel
+
+ssl_ctx = httpx.create_ssl_context(
+    cert=("/test/path/client.crt", "/test/path/client.key"),
+    verify="/test/path/ca.crt",
+    http2=True,
+)
 
 model: APIModel = APIModel(host="test", token="test", ssl_context=ssl_ctx)
 ```

--- a/grafana_api/admin.py
+++ b/grafana_api/admin.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from urllib3 import response
+from httpx import Response
 
 from .model import (
     APIModel,
@@ -544,13 +544,13 @@ class Admin:
             None
         """
 
-        api_call: response = Api(self.grafana_api_model).call_the_api(
+        api_call: Response = Api(self.grafana_api_model).call_the_api(
             f"{APIEndpoints.ADMIN.value}/encryption/rotate-data-keys",
             RequestsMethods.POST,
             json.dumps(dict()),
         )
 
-        if api_call.status != 204:
+        if api_call.status_code != 204:
             logging.error(f"Please, check the error: {api_call}.")
             raise Exception
         else:

--- a/grafana_api/alerting.py
+++ b/grafana_api/alerting.py
@@ -39,8 +39,8 @@ class Alerting:
             api_call (list): Returns the list of Alertmanager alerts
         """
 
-        if (type(recipient) == int and recipient != 0) or (
-            type(recipient) == str and len(recipient) != 0
+        if (isinstance(recipient, int) and recipient != 0) or (
+            isinstance(recipient, str) and len(recipient) != 0
         ):
             api_call: list = Api(self.grafana_api_model).call_the_api(
                 f"{APIEndpoints.ALERTS_ALERTMANAGER.value}/{recipient}/api/v2/alerts",
@@ -73,8 +73,8 @@ class Alerting:
         """
 
         if (
-            (type(recipient) == int and recipient != 0)
-            or (type(recipient) == str and len(recipient) != 0)
+            (isinstance(recipient, int) and recipient != 0)
+            or (isinstance(recipient, str) and len(recipient) != 0)
         ) and alerts != list():
             alerts_json_list: list = list()
 
@@ -119,8 +119,8 @@ class Alerting:
             api_call (list): Returns the list of Alertmanager group alerts
         """
 
-        if (type(recipient) == int and recipient != 0) or (
-            type(recipient) == str and len(recipient) != 0
+        if (isinstance(recipient, int) and recipient != 0) or (
+            isinstance(recipient, str) and len(recipient) != 0
         ):
             api_call: list = Api(self.grafana_api_model).call_the_api(
                 f"{APIEndpoints.ALERTS_ALERTMANAGER.value}/{recipient}/api/v2/alerts",
@@ -153,8 +153,8 @@ class Alerting:
         """
 
         if (
-            (type(recipient) == int and recipient != 0)
-            or (type(recipient) == str and len(recipient) != 0)
+            (isinstance(recipient, int) and recipient != 0)
+            or (isinstance(recipient, str) and len(recipient) != 0)
         ) and len(silence_id) != 0:
             api_call: dict = Api(self.grafana_api_model).call_the_api(
                 f"{APIEndpoints.ALERTS_ALERTMANAGER.value}/{recipient}/api/v2/silence/{silence_id}",
@@ -188,8 +188,8 @@ class Alerting:
         """
 
         if (
-            (type(recipient) == int and recipient != 0)
-            or (type(recipient) == str and len(recipient) != 0)
+            (isinstance(recipient, int) and recipient != 0)
+            or (isinstance(recipient, str) and len(recipient) != 0)
         ) and len(silence_id) != 0:
             api_call: dict = Api(self.grafana_api_model).call_the_api(
                 f"{APIEndpoints.ALERTS_ALERTMANAGER.value}/{recipient}/api/v2/silence/{silence_id}",
@@ -218,8 +218,8 @@ class Alerting:
             api_call (list): Returns the list of Alertmanager silence alerts
         """
 
-        if (type(recipient) == int and recipient != 0) or (
-            type(recipient) == str and len(recipient) != 0
+        if (isinstance(recipient, int) and recipient != 0) or (
+            isinstance(recipient, str) and len(recipient) != 0
         ):
             api_call: list = Api(self.grafana_api_model).call_the_api(
                 f"{APIEndpoints.ALERTS_ALERTMANAGER.value}/{recipient}/api/v2/silences",
@@ -252,8 +252,8 @@ class Alerting:
         """
 
         if (
-            (type(recipient) == int and recipient != 0)
-            or (type(recipient) == str and len(recipient) != 0)
+            (isinstance(recipient, int) and recipient != 0)
+            or (isinstance(recipient, str) and len(recipient) != 0)
         ) or silence is not None:
             silence_json_dict: dict = dict(
                 {
@@ -295,8 +295,8 @@ class Alerting:
             api_call (dict): Returns the dict of the Alertmanager status
         """
 
-        if (type(recipient) == int and recipient != 0) or (
-            type(recipient) == str and len(recipient) != 0
+        if (isinstance(recipient, int) and recipient != 0) or (
+            isinstance(recipient, str) and len(recipient) != 0
         ):
             api_call: dict = Api(self.grafana_api_model).call_the_api(
                 f"{APIEndpoints.ALERTS_ALERTMANAGER.value}/{recipient}/api/v2/status",
@@ -325,8 +325,8 @@ class Alerting:
             None
         """
 
-        if (type(recipient) == int and recipient != 0) or (
-            type(recipient) == str and len(recipient) != 0
+        if (isinstance(recipient, int) and recipient != 0) or (
+            isinstance(recipient, str) and len(recipient) != 0
         ):
             api_call: dict = Api(self.grafana_api_model).call_the_api(
                 f"{APIEndpoints.ALERTS_ALERTMANAGER.value}/{recipient}/config/api/v1/alerts",
@@ -359,8 +359,8 @@ class Alerting:
             api_call (dict): Returns the dict of the Alertmanager config
         """
 
-        if (type(recipient) == int and recipient != 0) or (
-            type(recipient) == str and len(recipient) != 0
+        if (isinstance(recipient, int) and recipient != 0) or (
+            isinstance(recipient, str) and len(recipient) != 0
         ):
             api_call: dict = Api(self.grafana_api_model).call_the_api(
                 f"{APIEndpoints.ALERTS_ALERTMANAGER.value}/{recipient}/config/api/v1/alerts",
@@ -397,8 +397,8 @@ class Alerting:
         """
 
         if (
-            (type(recipient) == int and recipient != 0)
-            or (type(recipient) == str and len(recipient) != 0)
+            (isinstance(recipient, int) and recipient != 0)
+            or (isinstance(recipient, str) and len(recipient) != 0)
         ) and alertmanager_config is not None:
             alertmanager_configuration_json_dict: dict = dict()
 
@@ -455,8 +455,8 @@ class Alerting:
 
         if (
             (
-                (type(recipient) == int and recipient != 0)
-                or (type(recipient) == str and len(recipient) != 0)
+                (isinstance(recipient, int) and recipient != 0)
+                or (isinstance(recipient, str) and len(recipient) != 0)
             )
             and alert != dict()
             and receivers is not None
@@ -535,8 +535,8 @@ class Alerting:
             api_call (dict): Returns the dict of the prometheus alerts
         """
 
-        if (type(recipient) == int and recipient != 0) or (
-            type(recipient) == str and len(recipient) != 0
+        if (isinstance(recipient, int) and recipient != 0) or (
+            isinstance(recipient, str) and len(recipient) != 0
         ):
             api_call: dict = Api(self.grafana_api_model).call_the_api(
                 f"{APIEndpoints.ALERTS_PROMETHEUS.value}/{recipient}/api/v1/alerts",
@@ -565,8 +565,8 @@ class Alerting:
             api_call (dict): Returns the dict of the prometheus rules
         """
 
-        if (type(recipient) == int and recipient != 0) or (
-            type(recipient) == str and len(recipient) != 0
+        if (isinstance(recipient, int) and recipient != 0) or (
+            isinstance(recipient, str) and len(recipient) != 0
         ):
             api_call: dict = Api(self.grafana_api_model).call_the_api(
                 f"{APIEndpoints.ALERTS_PROMETHEUS.value}/{recipient}/api/v1/rules",
@@ -595,8 +595,8 @@ class Alerting:
             api_call (dict): Returns the dict of the ruler rules
         """
 
-        if (type(recipient) == int and recipient != 0) or (
-            type(recipient) == str and len(recipient) != 0
+        if (isinstance(recipient, int) and recipient != 0) or (
+            isinstance(recipient, str) and len(recipient) != 0
         ):
             api_call: dict = Api(self.grafana_api_model).call_the_api(
                 f"{APIEndpoints.ALERTS_RULER.value}/{recipient}/api/v1/rules",
@@ -627,8 +627,8 @@ class Alerting:
         """
 
         if (
-            (type(recipient) == int and recipient != 0)
-            or (type(recipient) == str and len(recipient) != 0)
+            (isinstance(recipient, int) and recipient != 0)
+            or (isinstance(recipient, str) and len(recipient) != 0)
         ) and len(namespace) != 0:
             api_call: dict = Api(self.grafana_api_model).call_the_api(
                 f"{APIEndpoints.ALERTS_RULER.value}/{recipient}/api/v1/rules/{namespace}",
@@ -662,8 +662,8 @@ class Alerting:
         """
 
         if (
-            (type(recipient) == int and recipient != 0)
-            or (type(recipient) == str and len(recipient) != 0)
+            (isinstance(recipient, int) and recipient != 0)
+            or (isinstance(recipient, str) and len(recipient) != 0)
         ) and len(namespace) != 0:
             api_call: dict = Api(self.grafana_api_model).call_the_api(
                 f"{APIEndpoints.ALERTS_RULER.value}/{recipient}/api/v1/rules/{namespace}",
@@ -705,8 +705,8 @@ class Alerting:
 
         if (
             (
-                (type(recipient) == int and recipient != 0)
-                or (type(recipient) == str and len(recipient) != 0)
+                (isinstance(recipient, int) and recipient != 0)
+                or (isinstance(recipient, str) and len(recipient) != 0)
             )
             and len(namespace) != 0
             and len(group_name) != 0
@@ -769,8 +769,8 @@ class Alerting:
 
         if (
             (
-                (type(recipient) == int and recipient != 0)
-                or (type(recipient) == str and len(recipient) != 0)
+                (isinstance(recipient, int) and recipient != 0)
+                or (isinstance(recipient, str) and len(recipient) != 0)
             )
             and len(namespace) != 0
             and len(group_name) != 0
@@ -809,8 +809,8 @@ class Alerting:
 
         if (
             (
-                (type(recipient) == int and recipient != 0)
-                or (type(recipient) == str and len(recipient) != 0)
+                (isinstance(recipient, int) and recipient != 0)
+                or (isinstance(recipient, str) and len(recipient) != 0)
             )
             and len(namespace) != 0
             and len(group_name) != 0
@@ -907,8 +907,8 @@ class Alerting:
 
         if (
             (
-                (type(recipient) == int and recipient != 0)
-                or (type(recipient) == str and len(recipient) != 0)
+                (isinstance(recipient, int) and recipient != 0)
+                or (isinstance(recipient, str) and len(recipient) != 0)
             )
             and len(expr) != 0
             and len(condition) != 0

--- a/grafana_api/alerting_provisioning.py
+++ b/grafana_api/alerting_provisioning.py
@@ -94,7 +94,9 @@ class AlertingProvisioning:
             logging.error("There is no alert_rule defined.")
             raise ValueError
 
-    def update_alert_rule(self, uid: str, alert_rule: AlertRule, disable_provenance: bool = False):
+    def update_alert_rule(
+        self, uid: str, alert_rule: AlertRule, disable_provenance: bool = False
+    ):
         """The method includes a functionality to update an existing alert rule
 
         Args:
@@ -129,7 +131,11 @@ class AlertingProvisioning:
             raise ValueError
 
     def update_the_interval_of_a_alert_rule_group(
-        self, folder_uid: str, group: str, alert_rule_group_interval: int, disable_provenance: bool = False
+        self,
+        folder_uid: str,
+        group: str,
+        alert_rule_group_interval: int,
+        disable_provenance: bool = False,
     ):
         """The method includes a functionality to update the interval of a alert rule group
 
@@ -220,7 +226,11 @@ class AlertingProvisioning:
         else:
             return api_call
 
-    def add_contact_point(self, embedded_contact_point: EmbeddedContactPoint, disable_provenance: bool = False):
+    def add_contact_point(
+        self,
+        embedded_contact_point: EmbeddedContactPoint,
+        disable_provenance: bool = False,
+    ):
         """The method includes a functionality to create a contact point
 
         Args:
@@ -263,7 +273,10 @@ class AlertingProvisioning:
             raise ValueError
 
     def update_contact_point(
-        self, uid: str, embedded_contact_point: EmbeddedContactPoint, disable_provenance: bool = False
+        self,
+        uid: str,
+        embedded_contact_point: EmbeddedContactPoint,
+        disable_provenance: bool = False,
     ):
         """The method includes a functionality to update a contact point
 
@@ -405,7 +418,7 @@ class AlertingProvisioning:
             f"{APIEndpoints.ALERTING_PROVISIONING.value}/mute-timings",
         )
 
-        if type(api_call) != list:
+        if isinstance(api_call, list) is False:
             logging.error(f"Check the error: {api_call}.")
             raise Exception
         else:
@@ -439,7 +452,9 @@ class AlertingProvisioning:
             logging.error("There is no name defined.")
             raise ValueError
 
-    def add_mute_timing(self, mute_time_interval: MuteTimeInterval, disable_provenance: bool = False):
+    def add_mute_timing(
+        self, mute_time_interval: MuteTimeInterval, disable_provenance: bool = False
+    ):
         """The method includes a functionality to create a mute timing
 
         Args:
@@ -472,7 +487,12 @@ class AlertingProvisioning:
             logging.error("There is no mute_time_interval defined.")
             raise ValueError
 
-    def update_mute_timing(self, name: str, mute_time_interval: MuteTimeInterval, disable_provenance: bool = False):
+    def update_mute_timing(
+        self,
+        name: str,
+        mute_time_interval: MuteTimeInterval,
+        disable_provenance: bool = False,
+    ):
         """The method includes a functionality to update an existing mute timing
 
         Args:
@@ -550,7 +570,7 @@ class AlertingProvisioning:
             f"{APIEndpoints.ALERTING_PROVISIONING.value}/templates",
         )
 
-        if type(api_call) != list:
+        if isinstance(api_call, list) is False:
             logging.error(f"Check the error: {api_call}.")
             raise Exception
         else:
@@ -585,7 +605,9 @@ class AlertingProvisioning:
             logging.error("There is no name defined.")
             raise ValueError
 
-    def create_or_update_message_template(self, name: str, message_template: str, disable_provenance: bool = False):
+    def create_or_update_message_template(
+        self, name: str, message_template: str, disable_provenance: bool = False
+    ):
         """The method includes a functionality to create or update a message template
 
         Args:
@@ -684,7 +706,7 @@ class AlertingProvisioning:
 
         mute_timing_interval_list: list = list()
 
-        if time_intervals is not None and type(time_intervals) == list:
+        if time_intervals is not None and isinstance(time_intervals, list):
             for time_interval in time_intervals:
                 mute_timing_interval_list.append(
                     {
@@ -713,7 +735,7 @@ class AlertingProvisioning:
 
         timing_list: list = list()
 
-        if timing is not None and type(timing) == list:
+        if timing is not None and isinstance(timing, list):
             for time in timing:
                 timing_list.append(
                     {"start_time": time.start_time, "end_time": time.end_time}
@@ -762,7 +784,7 @@ class AlertingProvisioning:
 
         routes_list: list = list()
 
-        if routes is not None and type(routes) == list:
+        if routes is not None and isinstance(routes, list):
             for route in routes:
                 routes_list.append(self.__create_alert_route_dictionary(route))
 
@@ -783,7 +805,7 @@ class AlertingProvisioning:
 
         route_matchers_list: list = list()
 
-        if matchers is not None and type(matchers) == list:
+        if matchers is not None and isinstance(matchers, list):
             for matcher in matchers:
                 route_matcher_dict: dict = dict(
                     {

--- a/grafana_api/dashboard.py
+++ b/grafana_api/dashboard.py
@@ -567,11 +567,11 @@ class Dashboard:
                     json.dumps(diff_object),
                 )
 
-                if api_call.status != 200:
-                    logging.error(f"Check the error: {api_call.data}.")
+                if api_call.status_code != 200:
+                    logging.error(f"Check the error: {api_call.text}.")
                     raise Exception
                 else:
-                    return api_call.data
+                    return api_call.text
             else:
                 logging.error(
                     "There is no dashboard_uid_and_version_base or dashboard_uid_and_version_new defined."

--- a/grafana_api/datasource.py
+++ b/grafana_api/datasource.py
@@ -712,7 +712,9 @@ class DatasourceQueryResourceCaching:
             logging.error("There is no uid defined.")
             raise ValueError
 
-    def update_datasource_cache(self, uid: str, datasource_cache: DatasourceCache) -> dict:
+    def update_datasource_cache(
+        self, uid: str, datasource_cache: DatasourceCache
+    ) -> dict:
         """The method includes a functionality to update the datasource cache specified by the datasource uid
 
         Args:
@@ -755,7 +757,7 @@ class DatasourceQueryResourceCaching:
             api_call: dict = Api(self.grafana_api_model).call_the_api(
                 f"{APIEndpoints.DATASOURCES.value}/{uid}/cache",
                 RequestsMethods.POST,
-                json.dumps(datasource_cache_object)
+                json.dumps(datasource_cache_object),
             )
 
             if api_call == dict() or api_call.get("dataSourceID") is None:
@@ -764,5 +766,7 @@ class DatasourceQueryResourceCaching:
             else:
                 return api_call
         else:
-            logging.error("There is no uid or the right datasource_cache object defined.")
+            logging.error(
+                "There is no uid or the right datasource_cache object defined."
+            )
             raise ValueError

--- a/grafana_api/folder.py
+++ b/grafana_api/folder.py
@@ -197,7 +197,7 @@ class Folder:
                 RequestsMethods.DELETE,
             )
 
-            if api_call.status != 200:
+            if api_call.status_code != 200:
                 logging.error(f"Please, check the error: {api_call}.")
                 raise Exception
             else:

--- a/grafana_api/legacy_alerting.py
+++ b/grafana_api/legacy_alerting.py
@@ -116,7 +116,7 @@ class Alerting:
         """
 
         def _to_camel_case(input_value: str) -> str:
-            content = re.findall('[A-Z][^A-Z]*', input_value)
+            content = re.findall("[A-Z][^A-Z]*", input_value)
             if content != list():
                 if len(content) != 1:
                     return content[0].lower() + "".join(content[1:])

--- a/grafana_api/licensing.py
+++ b/grafana_api/licensing.py
@@ -1,5 +1,5 @@
 import json
-from urllib3 import response
+from httpx import Response
 import logging
 
 from .model import (
@@ -39,15 +39,15 @@ class Licensing:
             api_call (bool): Returns the result if the license is available or not
         """
 
-        api_call: response = Api(self.grafana_api_model).call_the_api(
+        api_call: Response = Api(self.grafana_api_model).call_the_api(
             f"{APIEndpoints.LICENSING.value}/check",
         )
 
-        if api_call.status != 200:
+        if api_call.status_code != 200:
             logging.error(f"Check the error: {api_call}.")
             raise Exception
         else:
-            return json.loads(str(api_call.data.decode("utf-8")))
+            return json.loads(str(api_call.text))
 
     def manually_force_license_refresh(self):
         """The method includes a functionality to manually ask license issuer for a new token

--- a/grafana_api/model.py
+++ b/grafana_api/model.py
@@ -1,4 +1,5 @@
 import ssl
+import httpx
 from enum import Enum
 from typing import List, TypeVar
 from dataclasses import dataclass, field
@@ -78,6 +79,7 @@ class APIModel:
         username (str): Specify the username of the Grafana system
         password (str): Specify the password of the Grafana system
         timeout (float): Specify the timeout of the Grafana system
+        http2_support (bool): Specify if you want to use HTTP/2
         ssl_context (ssl.SSLContext): Specify the custom ssl context of the Grafana system
         num_pools (int): Specify the number of the connection pool
         retries (any): Specify the number of the retries. Please use False as parameter to disable the retries
@@ -88,7 +90,8 @@ class APIModel:
     username: str = None
     password: str = None
     timeout: float = 10.0
-    ssl_context: ssl.SSLContext = ssl.create_default_context()
+    http2_support: bool = False
+    ssl_context: ssl.SSLContext = httpx.create_ssl_context(http2=http2_support)
     num_pools: int = 10
     retries: any = 10
 

--- a/grafana_api/other_http.py
+++ b/grafana_api/other_http.py
@@ -1,6 +1,9 @@
 import logging
+from typing import Union
+import asyncio
 
-import urllib3
+from httpx import AsyncClient, Client, BasicAuth, Response
+
 import json
 
 from .model import APIModel, APIEndpoints
@@ -49,7 +52,9 @@ class OtherHTTP:
         Returns:
             None
         """
-        api_call: dict = Api(self.grafana_api_model).call_the_api(f"{APIEndpoints.LOGIN.value}/ping")
+        api_call: dict = Api(self.grafana_api_model).call_the_api(
+            f"{APIEndpoints.LOGIN.value}/ping"
+        )
 
         if api_call.get("message") != "Logged in":
             logging.error(f"Check the error: {api_call}.")
@@ -67,18 +72,13 @@ class OtherHTTP:
             api_call (dict): Returns the health information
         """
 
-        http = urllib3.PoolManager(
-            num_pools=self.grafana_api_model.num_pools,
-            retries=self.grafana_api_model.retries,
-            timeout=self.grafana_api_model.timeout,
-            ssl_context=self.grafana_api_model.ssl_context,
+        http = Api(self.grafana_api_model).create_the_http_api_client()
+
+        http_result = self._basic_get_call_without_token_auth(
+            http, f"{self.grafana_api_model.host}/api/health"
         )
 
-        api_call: dict = json.loads(
-            http.request(
-                "GET", f"{self.grafana_api_model.host}/api/health"
-            ).data.decode("utf-8")
-        )
+        api_call: dict = json.loads(http_result.text)
 
         if api_call == dict() or api_call.get("commit") is None:
             logging.error(f"Check the error: {api_call}.")
@@ -86,8 +86,14 @@ class OtherHTTP:
         else:
             return api_call
 
-    def get_metrics(self) -> str:
+    def get_metrics(
+        self, basic_auth_username: str = None, basic_auth_password: str = None
+    ) -> str:
         """The method includes a functionality to get the Grafana metrics information
+
+        Args:
+            basic_auth_username (str): Specify the optional basic auth username
+            basic_auth_password (str): Specify the optional basic auth password
 
         Raises:
             Exception: Unspecified error by executing the API call
@@ -96,19 +102,90 @@ class OtherHTTP:
             api_call (str): Returns the metrics information
         """
 
-        http = urllib3.PoolManager(
-            num_pools=self.grafana_api_model.num_pools,
-            retries=self.grafana_api_model.retries,
-            timeout=self.grafana_api_model.timeout,
-            ssl_context=self.grafana_api_model.ssl_context,
-        )
+        http = Api(self.grafana_api_model).create_the_http_api_client()
 
-        api_call: str = http.request(
-            "GET", f"{self.grafana_api_model.host}/metrics"
-        ).data.decode("utf-8")
+        basic_auth = None
+        if basic_auth_username is not None and basic_auth_password is not None:
+            basic_auth = BasicAuth(basic_auth_username, basic_auth_password)
+
+        api_call: str = self._basic_get_call_without_token_auth(
+            http, f"{self.grafana_api_model.host}/metrics", basic_auth
+        ).text
 
         if len(api_call) == 0 or api_call is None:
             logging.error(f"Check the error: {api_call}.")
             raise Exception
         else:
             return api_call
+
+    def get_plugin_metrics(
+        self,
+        plugin_id: str,
+        basic_auth_username: str = None,
+        basic_auth_password: str = None,
+    ) -> str:
+        """The method includes a functionality to get the Grafana plugin metrics information
+
+        Args:
+            plugin_id (str): Specify the plugin id
+            basic_auth_username (str): Specify the optional basic auth username
+            basic_auth_password (str): Specify the optional basic auth password
+
+        Raises:
+            ValueError: Missed specifying a necessary value
+            Exception: Unspecified error by executing the API call
+
+        Returns:
+            api_call (str): Returns the metrics information
+        """
+
+        http = Api(self.grafana_api_model).create_the_http_api_client()
+
+        basic_auth = None
+        if basic_auth_username is not None and basic_auth_password is not None:
+            basic_auth = BasicAuth(basic_auth_username, basic_auth_password)
+
+        if len(plugin_id) != 0:
+            url: str = f"{self.grafana_api_model.host}/metrics/plugins/{plugin_id}"
+            api_call: str = self._basic_get_call_without_token_auth(
+                http, url, basic_auth
+            ).text
+
+            if len(api_call) == 0 or api_call is None:
+                logging.error(f"Check the error: {api_call}.")
+                raise Exception
+            else:
+                return api_call
+        else:
+            logging.error("There is no plugin_id defined.")
+            raise ValueError
+
+    def _basic_get_call_without_token_auth(
+        self, http: Union[Client, AsyncClient], url: str, basic_auth: BasicAuth = None
+    ) -> Response:
+        """The method includes a functionality to perform a basic GET call to an endpoint with optional BasicAuth
+
+        Args:
+            http (Union[Client, AsyncClient]): Specify the used client
+            url (str): Specify the url of the performed api call
+            basic_auth (BasicAuth): Specify the optional basic auth credentials (Default None)
+
+        Raises:
+            Exception: Unspecified error by executing the API call
+
+        Returns:
+            api_call (Response): Returns the corresponding result of the api call
+        """
+
+        try:
+            if self.grafana_api_model.http2_support:
+
+                async def _execute_async_http_requests():
+                    async with http:
+                        return await http.request("GET", url, auth=basic_auth)
+
+                return asyncio.run(_execute_async_http_requests())
+            else:
+                return http.request("GET", url, auth=basic_auth)
+        except Exception as e:
+            raise e

--- a/grafana_api/playlist.py
+++ b/grafana_api/playlist.py
@@ -263,8 +263,8 @@ class Playlist:
                 RequestsMethods.DELETE,
             )
 
-            if api_call.status != 200:
-                logging.error(f"Check the error: {api_call.data}.")
+            if api_call.status_code != 200:
+                logging.error(f"Check the error: {api_call.text}.")
                 raise Exception
             else:
                 logging.info("You successfully deleted the corresponding playlist.")

--- a/grafana_api/preferences.py
+++ b/grafana_api/preferences.py
@@ -34,7 +34,7 @@ class Preferences:
             APIEndpoints.USER_PREFERENCES.value,
         )
 
-        if type(api_call) != dict or api_call == dict():
+        if isinstance(api_call, dict) is False or api_call == dict():
             logging.error(f"Check the error: {api_call}.")
             raise Exception
         else:
@@ -73,7 +73,7 @@ class Preferences:
             if theme is not None:
                 modified_values.update(dict({"theme": theme}))
 
-            if home_dashboard_id != 0 and type(home_dashboard_id) == int:
+            if home_dashboard_id != 0 and isinstance(home_dashboard_id, int):
                 modified_values.update(dict({"homeDashboardId": home_dashboard_id}))
             else:
                 modified_values.update({"homeDashboardUID": home_dashboard_uid})
@@ -112,7 +112,7 @@ class Preferences:
             APIEndpoints.ORG_PREFERENCES.value,
         )
 
-        if type(api_call) != dict or api_call == dict():
+        if isinstance(api_call, dict) is False or api_call == dict():
             logging.error(f"Check the error: {api_call}.")
             raise Exception
         else:
@@ -151,7 +151,7 @@ class Preferences:
             if theme is not None:
                 modified_values.update(dict({"theme": theme}))
 
-            if home_dashboard_id != 0 and type(home_dashboard_id) == int:
+            if home_dashboard_id != 0 and isinstance(home_dashboard_id, int):
                 modified_values.update(dict({"homeDashboardId": home_dashboard_id}))
             else:
                 modified_values.update({"homeDashboardUID": home_dashboard_uid})

--- a/grafana_api/service_account.py
+++ b/grafana_api/service_account.py
@@ -312,7 +312,10 @@ class ServiceAccount:
             json.dumps(dict()),
         )
 
-        if api_call.get("migrated") is None and api_call.get("message") != "API keys migrated to service accounts":
+        if (
+            api_call.get("migrated") is None
+            and api_call.get("message") != "API keys migrated to service accounts"
+        ):
             logging.error(f"Check the error: {api_call}.")
             raise Exception
         else:

--- a/grafana_api/team.py
+++ b/grafana_api/team.py
@@ -322,7 +322,7 @@ class Team:
                 f"{APIEndpoints.TEAMS.value}/{id}/preferences",
             )
 
-            if type(api_call) != dict or api_call == dict():
+            if isinstance(api_call, dict) is False or api_call == dict():
                 logging.error(f"Check the error: {api_call}.")
                 raise Exception
             else:
@@ -370,7 +370,7 @@ class Team:
             if theme is not None:
                 team_preferences.update(dict({"theme": theme}))
 
-            if home_dashboard_id != 0 and type(home_dashboard_id) == int:
+            if home_dashboard_id != 0 and isinstance(home_dashboard_id, int):
                 team_preferences.update(dict({"homeDashboardId": home_dashboard_id}))
             else:
                 team_preferences.update({"homeDashboardUID": home_dashboard_uid})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-pydoc-markdown==4.6.3
-mkdocs
-mkdocs-material
-setuptools~=65.5.1
-urllib3~=1.26.7
+httpx[http2]~=0.24.1
+pytest
+pytest-httpx

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,13 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     packages=["grafana_api"],
-    install_requires=["urllib3"],
-    python_requires=">=3.6",
+    install_requires=["httpx"],
+    extras_require={
+        "http2": ["httpx[http2]"],
+    },
+    tests_require={
+        "pytest-httpx",
+        "pytest"
+    },
+    python_requires=">=3.8",
 )

--- a/tests/integrationtest/test_alerting.py
+++ b/tests/integrationtest/test_alerting.py
@@ -1,4 +1,5 @@
 import os
+
 import time
 from unittest import TestCase
 
@@ -15,6 +16,7 @@ class AlertingTest(TestCase):
     model: APIModel = APIModel(
         host=os.environ["GRAFANA_HOST"],
         token=os.environ["GRAFANA_TOKEN"],
+        http2_support=True if os.environ["HTTP2"] == "True" else False,
     )
     alerting: Alerting = Alerting(model)
 
@@ -124,10 +126,19 @@ class AlertingTest(TestCase):
         MAX_TRIES: int = 3
 
         for i in range(0, MAX_TRIES):
-            if len(self.alerting.get_prometheus_alerts().get("data").get("alerts")) != 0:
+            if (
+                len(self.alerting.get_prometheus_alerts().get("data").get("alerts"))
+                != 0
+            ):
                 time.sleep(0.1 + i / 2)
-                self.assertEqual("Test",
-                                 self.alerting.get_prometheus_alerts().get("data").get("alerts")[0].get("labels").get("alertname"))
+                self.assertEqual(
+                    "Test",
+                    self.alerting.get_prometheus_alerts()
+                    .get("data")
+                    .get("alerts")[0]
+                    .get("labels")
+                    .get("alertname"),
+                )
             elif i == MAX_TRIES:
                 self.fail("Conditions not yet fulfilled.")
 

--- a/tests/integrationtest/test_alerting_notifications.py
+++ b/tests/integrationtest/test_alerting_notifications.py
@@ -1,4 +1,5 @@
 import os
+
 from unittest import TestCase
 
 from grafana_api.model import APIModel
@@ -9,6 +10,7 @@ class AlertingNotificationsTest(TestCase):
     model: APIModel = APIModel(
         host=os.environ["GRAFANA_HOST"],
         token=os.environ["GRAFANA_TOKEN"],
+        http2_support=True if os.environ["HTTP2"] == "True" else False,
     )
     alerting_notifications: AlertingNotifications = AlertingNotifications(model)
 

--- a/tests/integrationtest/test_alerting_provisioning.py
+++ b/tests/integrationtest/test_alerting_provisioning.py
@@ -1,4 +1,5 @@
 import os
+
 import time
 from unittest import TestCase
 
@@ -21,6 +22,7 @@ class AlertingProvisioningTest(TestCase):
     model: APIModel = APIModel(
         host=os.environ["GRAFANA_HOST"],
         token=os.environ["GRAFANA_TOKEN"],
+        http2_support=True if os.environ["HTTP2"] == "True" else False,
     )
     alerting_provisioning: AlertingProvisioning = AlertingProvisioning(model)
 

--- a/tests/integrationtest/test_annotations.py
+++ b/tests/integrationtest/test_annotations.py
@@ -1,4 +1,5 @@
 import os
+
 from unittest import TestCase
 
 from grafana_api.model import (
@@ -14,6 +15,7 @@ class AnnotationsTest(TestCase):
     model: APIModel = APIModel(
         host=os.environ["GRAFANA_HOST"],
         token=os.environ["GRAFANA_TOKEN"],
+        http2_support=True if os.environ["HTTP2"] == "True" else False,
     )
     annotations: Annotations = Annotations(model)
 

--- a/tests/integrationtest/test_api.py
+++ b/tests/integrationtest/test_api.py
@@ -1,0 +1,36 @@
+import os
+import asyncio
+
+from unittest import TestCase
+
+from grafana_api.model import (
+    APIModel,
+)
+from grafana_api.api import Api
+
+
+class APITest(TestCase):
+    https2_support: bool = True if os.environ["HTTP2"] == "True" else False
+    print(https2_support)
+    model: APIModel = APIModel(
+        host=os.environ["GRAFANA_HOST"],
+        token=os.environ["GRAFANA_TOKEN"],
+        http2_support=https2_support,
+    )
+    api: Api = Api(model)
+
+    def test_get_http_client_version(self):
+        http = self.api.create_the_http_api_client()
+        url: str = f"{self.model.host}/api/health"
+
+        if self.https2_support:
+
+            async def _execute_async_http_requests():
+                async with http:
+                    return await http.request("GET", url)
+
+            response = asyncio.run(_execute_async_http_requests())
+            self.assertEqual("HTTP/2", response.http_version)
+        else:
+            response = http.request("GET", url)
+            self.assertEqual("HTTP/1.1", response.http_version)

--- a/tests/integrationtest/test_authentication.py
+++ b/tests/integrationtest/test_authentication.py
@@ -1,4 +1,5 @@
 import os
+
 from unittest import TestCase
 
 from grafana_api.model import (
@@ -11,6 +12,7 @@ class AuthenticationTest(TestCase):
     model: APIModel = APIModel(
         host=os.environ["GRAFANA_HOST"],
         token=os.environ["GRAFANA_TOKEN"],
+        http2_support=True if os.environ["HTTP2"] == "True" else False,
     )
     authentication: Authentication = Authentication(model)
 

--- a/tests/integrationtest/test_correlations.py
+++ b/tests/integrationtest/test_correlations.py
@@ -1,4 +1,5 @@
 import os
+
 from unittest import TestCase
 
 from grafana_api.model import APIModel, CorrelationObject
@@ -10,6 +11,7 @@ class CorrelationsTest(TestCase):
     model: APIModel = APIModel(
         host=os.environ["GRAFANA_HOST"],
         token=os.environ["GRAFANA_TOKEN"],
+        http2_support=True if os.environ["HTTP2"] == "True" else False,
     )
     data_source: Datasource = Datasource(model)
     correlations: Correlations = Correlations(model)

--- a/tests/integrationtest/test_dashboard.py
+++ b/tests/integrationtest/test_dashboard.py
@@ -1,8 +1,9 @@
 import os
+
 import json
 from unittest import TestCase
 
-import urllib3
+import httpx
 
 from grafana_api.model import APIModel
 from grafana_api.dashboard import Dashboard
@@ -13,6 +14,7 @@ class DashboardTest(TestCase):
     model: APIModel = APIModel(
         host=os.environ["GRAFANA_HOST"],
         token=os.environ["GRAFANA_TOKEN"],
+        http2_support=True if os.environ["HTTP2"] == "True" else False,
     )
     dashboard: Dashboard = Dashboard(model)
     folder: Folder = Folder(model)
@@ -99,7 +101,7 @@ class DashboardTest(TestCase):
 
         dashboard: Dashboard = Dashboard(model)
 
-        with self.assertRaises(urllib3.exceptions.ConnectionError):
+        with self.assertRaises(httpx.ConnectError):
             dashboard.delete_dashboard_by_name_and_path(
                 dashboard_path=os.environ["GRAFANA_DASHBOARD_PATH"],
                 dashboard_name=os.environ["GRAFANA_DASHBOARD_NAME"],

--- a/tests/integrationtest/test_datasource.py
+++ b/tests/integrationtest/test_datasource.py
@@ -1,4 +1,5 @@
 import os
+
 from unittest import TestCase
 
 from grafana_api.model import APIModel
@@ -9,6 +10,7 @@ class DataSourceTest(TestCase):
     model: APIModel = APIModel(
         host=os.environ["GRAFANA_HOST"],
         token=os.environ["GRAFANA_TOKEN"],
+        http2_support=True if os.environ["HTTP2"] == "True" else False,
     )
     data_source: Datasource = Datasource(model)
 

--- a/tests/integrationtest/test_folder.py
+++ b/tests/integrationtest/test_folder.py
@@ -1,4 +1,5 @@
 import os
+
 from unittest import TestCase
 
 from grafana_api.model import APIModel
@@ -9,6 +10,7 @@ class FolderTest(TestCase):
     model: APIModel = APIModel(
         host=os.environ["GRAFANA_HOST"],
         token=os.environ["GRAFANA_TOKEN"],
+        http2_support=True if os.environ["HTTP2"] == "True" else False,
     )
     folder: Folder = Folder(model)
 

--- a/tests/integrationtest/test_library.py
+++ b/tests/integrationtest/test_library.py
@@ -1,4 +1,5 @@
 import os
+
 from unittest import TestCase
 
 from grafana_api.model import APIModel
@@ -9,6 +10,7 @@ class LibraryTest(TestCase):
     model: APIModel = APIModel(
         host=os.environ["GRAFANA_HOST"],
         token=os.environ["GRAFANA_TOKEN"],
+        http2_support=True if os.environ["HTTP2"] == "True" else False,
     )
     library: Library = Library(model)
 

--- a/tests/integrationtest/test_organisation.py
+++ b/tests/integrationtest/test_organisation.py
@@ -1,4 +1,5 @@
 import os
+
 from unittest import TestCase
 
 from grafana_api.model import (
@@ -11,6 +12,7 @@ class OrganisationTest(TestCase):
     model: APIModel = APIModel(
         host=os.environ["GRAFANA_HOST"],
         token=os.environ["GRAFANA_TOKEN"],
+        http2_support=True if os.environ["HTTP2"] == "True" else False,
     )
     organisation: Organisation = Organisation(model)
 

--- a/tests/integrationtest/test_other_http.py
+++ b/tests/integrationtest/test_other_http.py
@@ -1,4 +1,5 @@
 import os
+
 from unittest import TestCase
 
 from grafana_api.model import (
@@ -11,6 +12,7 @@ class OtherHTTPTest(TestCase):
     model: APIModel = APIModel(
         host=os.environ["GRAFANA_HOST"],
         token=os.environ["GRAFANA_TOKEN"],
+        http2_support=True if os.environ["HTTP2"] == "True" else False,
     )
     other_http: OtherHTTP = OtherHTTP(model)
 

--- a/tests/integrationtest/test_playlist.py
+++ b/tests/integrationtest/test_playlist.py
@@ -1,4 +1,5 @@
 import os
+
 from unittest import TestCase
 
 from grafana_api.model import APIModel, PlaylistObject, PlaylistItemObject
@@ -9,6 +10,7 @@ class PlaylistTest(TestCase):
     model: APIModel = APIModel(
         host=os.environ["GRAFANA_HOST"],
         token=os.environ["GRAFANA_TOKEN"],
+        http2_support=True if os.environ["HTTP2"] == "True" else False,
     )
     playlist: Playlist = Playlist(model)
 

--- a/tests/integrationtest/test_preferences.py
+++ b/tests/integrationtest/test_preferences.py
@@ -1,4 +1,5 @@
 import os
+
 from unittest import TestCase
 
 from grafana_api.model import (
@@ -11,6 +12,7 @@ class PreferencesTest(TestCase):
     model: APIModel = APIModel(
         host=os.environ["GRAFANA_HOST"],
         token=os.environ["GRAFANA_TOKEN"],
+        http2_support=True if os.environ["HTTP2"] == "True" else False,
     )
     preferences: Preferences = Preferences(model)
 

--- a/tests/integrationtest/test_query_history.py
+++ b/tests/integrationtest/test_query_history.py
@@ -1,4 +1,5 @@
 import os
+
 from unittest import TestCase
 
 from grafana_api.model import (
@@ -14,6 +15,7 @@ class QueryHistoryTest(TestCase):
     model: APIModel = APIModel(
         host=os.environ["GRAFANA_HOST"],
         token=os.environ["GRAFANA_TOKEN"],
+        http2_support=True if os.environ["HTTP2"] == "True" else False,
     )
     data_source: Datasource = Datasource(model)
     query_history: QueryHistory = QueryHistory(model)

--- a/tests/integrationtest/test_service_account.py
+++ b/tests/integrationtest/test_service_account.py
@@ -1,4 +1,5 @@
 import os
+
 from unittest import TestCase
 
 from grafana_api.model import APIModel
@@ -10,6 +11,7 @@ class ServiceAccountTest(TestCase):
     model: APIModel = APIModel(
         host=os.environ["GRAFANA_HOST"],
         token=os.environ["GRAFANA_TOKEN"],
+        http2_support=True if os.environ["HTTP2"] == "True" else False,
     )
     service_account: ServiceAccount = ServiceAccount(grafana_api_model=model)
     authentication: Authentication = Authentication(grafana_api_model=model)
@@ -89,7 +91,9 @@ class ServiceAccountTest(TestCase):
         )
 
         self.service_account.delete_service_account(service_account.get("id"))
-        self.service_account.delete_service_account(service_account_migrated.get("serviceAccounts")[0].get("id"))
+        self.service_account.delete_service_account(
+            service_account_migrated.get("serviceAccounts")[0].get("id")
+        )
         self.assertEqual(
             1, len(self.service_account.search_service_account().get("serviceAccounts"))
         )

--- a/tests/integrationtest/test_short_url.py
+++ b/tests/integrationtest/test_short_url.py
@@ -1,4 +1,5 @@
 import os
+
 from unittest import TestCase
 
 from grafana_api.model import APIModel
@@ -9,6 +10,7 @@ class ShortUrlTest(TestCase):
     model: APIModel = APIModel(
         host=os.environ["GRAFANA_HOST"],
         token=os.environ["GRAFANA_TOKEN"],
+        http2_support=True if os.environ["HTTP2"] == "True" else False,
     )
     short_url: ShortUrl = ShortUrl(model)
 

--- a/tests/integrationtest/test_snapshot.py
+++ b/tests/integrationtest/test_snapshot.py
@@ -1,4 +1,5 @@
 import os
+
 from unittest import TestCase
 
 from grafana_api.model import APIModel
@@ -10,6 +11,7 @@ class SnapshotTest(TestCase):
     model: APIModel = APIModel(
         host=os.environ["GRAFANA_HOST"],
         token=os.environ["GRAFANA_TOKEN"],
+        http2_support=True if os.environ["HTTP2"] == "True" else False,
     )
     snapshot: Snapshot = Snapshot(model)
     dashboard: Dashboard = Dashboard(model)

--- a/tests/integrationtest/test_team.py
+++ b/tests/integrationtest/test_team.py
@@ -1,4 +1,5 @@
 import os
+
 from unittest import TestCase
 
 from grafana_api.model import APIModel, TeamObject
@@ -10,6 +11,7 @@ class TeamTest(TestCase):
     model: APIModel = APIModel(
         host=os.environ["GRAFANA_HOST"],
         token=os.environ["GRAFANA_TOKEN"],
+        http2_support=True if os.environ["HTTP2"] == "True" else False,
     )
     team: Team = Team(model)
 

--- a/tests/integrationtest/test_user.py
+++ b/tests/integrationtest/test_user.py
@@ -11,6 +11,7 @@ class CurrentUserTest(TestCase):
         host=os.environ["GRAFANA_HOST"],
         username=os.environ["GRAFANA_USERNAME"],
         password=os.environ["GRAFANA_PASSWORD"],
+        http2_support=True if os.environ["HTTP2"] == "True" else False,
     )
     current_user: CurrentUser = CurrentUser(model)
     dashboard: Dashboard = Dashboard(model)

--- a/tests/unittests/test_admin.py
+++ b/tests/unittests/test_admin.py
@@ -677,7 +677,7 @@ class AdminTestCase(TestCase):
         admin: Admin = Admin(grafana_api_model=model)
 
         mock: Mock = Mock()
-        mock.status = 204
+        mock.status_code = 204
 
         call_the_api_mock.return_value = mock
 
@@ -694,7 +694,7 @@ class AdminTestCase(TestCase):
         admin: Admin = Admin(grafana_api_model=model)
 
         mock: Mock = Mock()
-        mock.status = 400
+        mock.status_code = 400
 
         call_the_api_mock.return_value = mock
 

--- a/tests/unittests/test_api.py
+++ b/tests/unittests/test_api.py
@@ -1,5 +1,7 @@
-from urllib3 import exceptions
+from httpx import ConnectError, UnsupportedProtocol
 
+import pytest
+from pytest_httpx import HTTPXMock
 from unittest import TestCase
 from unittest.mock import MagicMock, patch, Mock
 
@@ -19,41 +21,49 @@ class ApiTestCase(TestCase):
         with self.assertRaises(Exception):
             self.api.call_the_api(api_call=MagicMock(), method=MagicMock())
 
-    @patch("urllib3.PoolManager")
-    def test_call_the_api_basic_auth(self, pool_mock):
+    @patch("httpx.Client")
+    def test_call_the_api_basic_auth(self, httpx_client_mock):
         model: APIModel = APIModel(
             host="https://test.test.de", username="test", password="test"
         )
         api: Api = Api(grafana_api_model=model)
 
-        pool_mock.return_value.request.return_value.data = b'{"status": 200}'
+        httpx_client_mock.return_value.request.return_value.text = '{"status": 200}'
 
         self.assertEqual(
             200,
             api.call_the_api(api_call=MagicMock())["status"],
         )
 
-    @patch("urllib3.PoolManager")
-    def test_call_the_api_org_id(self, pool_mock):
-        pool_mock.return_value.request.return_value.data = b'{"status": "success"}'
+    @patch("httpx.Client")
+    def test_call_the_api_org_id(self, httpx_client_mock):
+        httpx_client_mock.return_value.request.return_value.text = (
+            '{"status": "success"}'
+        )
 
         self.assertEqual(
             "success",
             self.api.call_the_api(api_call=MagicMock(), org_id_header=1)["status"],
         )
 
-    @patch("urllib3.PoolManager")
-    def test_call_the_api_disable_provenance(self, pool_mock):
-        pool_mock.return_value.request.return_value.data = b'{"status": "success"}'
+    @patch("httpx.Client")
+    def test_call_the_api_disable_provenance(self, httpx_client_mock):
+        httpx_client_mock.return_value.request.return_value.text = (
+            '{"status": "success"}'
+        )
 
         self.assertEqual(
             "success",
-            self.api.call_the_api(api_call=MagicMock(), disable_provenance_header=True)["status"],
+            self.api.call_the_api(api_call=MagicMock(), disable_provenance_header=True)[
+                "status"
+            ],
         )
 
-    @patch("urllib3.PoolManager")
-    def test_call_the_api_get_valid(self, pool_mock):
-        pool_mock.return_value.request.return_value.data = b'{"status": "success"}'
+    @patch("httpx.Client")
+    def test_call_the_api_get_valid(self, httpx_client_mock):
+        httpx_client_mock.return_value.request.return_value.text = (
+            '{"status": "success"}'
+        )
 
         self.assertEqual(
             "success",
@@ -61,19 +71,21 @@ class ApiTestCase(TestCase):
         )
 
     def test_call_the_api_get_not_valid(self):
-        with self.assertRaises(exceptions.MaxRetryError):
+        with self.assertRaises(UnsupportedProtocol):
             self.api.call_the_api(api_call=MagicMock(), method=RequestsMethods.GET)
 
-    @patch("urllib3.PoolManager")
-    def test_call_the_api_put_valid(self, pool_mock):
-        pool_mock.return_value.request.return_value.data = b'{"status": "success"}'
+    @patch("httpx.Client")
+    def test_call_the_api_put_valid(self, httpx_client_mock):
+        httpx_client_mock.return_value.request.return_value.text = (
+            '{"status": "success"}'
+        )
 
         self.assertEqual(
             "success",
             self.api.call_the_api(
                 api_call=MagicMock(),
                 method=RequestsMethods.PUT,
-                json_complete=MagicMock(),
+                json_complete='{"test": "test"}',
             )["status"],
         )
 
@@ -81,60 +93,64 @@ class ApiTestCase(TestCase):
         with self.assertRaises(Exception):
             self.api.call_the_api(api_call=MagicMock(), method=RequestsMethods.PUT)
 
-    @patch("urllib3.PoolManager")
-    def test_call_the_api_post_valid(self, pool_mock):
-        pool_mock.return_value.request.return_value.data = b'{"status": "success"}'
+    @patch("httpx.Client")
+    def test_call_the_api_post_valid(self, httpx_client_mock):
+        httpx_client_mock.return_value.request.return_value.text = (
+            '{"status": "success"}'
+        )
 
         self.assertEqual(
             "success",
             self.api.call_the_api(
                 api_call=MagicMock(),
                 method=RequestsMethods.POST,
-                json_complete=MagicMock(),
+                json_complete='{"test": "test"}',
             )["status"],
         )
 
     def test_call_the_api_post_not_valid(self):
-        with self.assertRaises(exceptions.ProtocolError):
+        with self.assertRaises(UnsupportedProtocol):
             self.api.call_the_api(
                 api_call=MagicMock(),
                 method=RequestsMethods.POST,
-                json_complete=MagicMock(),
+                json_complete='{"test": "test"}',
             )
 
     def test_call_the_api_post_no_data(self):
         with self.assertRaises(Exception):
             self.api.call_the_api(api_call=MagicMock(), method=RequestsMethods.POST)
 
-    @patch("urllib3.PoolManager")
-    def test_call_the_api_patch_valid(self, pool_mock):
-        pool_mock.return_value.request.return_value.data = b'{"status": "success"}'
+    @patch("httpx.Client")
+    def test_call_the_api_patch_valid(self, httpx_client_mock):
+        httpx_client_mock.return_value.request.return_value.text = (
+            '{"status": "success"}'
+        )
 
         self.assertEqual(
             "success",
             self.api.call_the_api(
                 api_call=MagicMock(),
                 method=RequestsMethods.PATCH,
-                json_complete=MagicMock(),
+                json_complete='{"test": "test"}',
             )["status"],
         )
 
     def test_call_the_api_patch_not_valid(self):
-        with self.assertRaises(exceptions.ProtocolError):
+        with self.assertRaises(UnsupportedProtocol):
             self.api.call_the_api(
                 api_call=MagicMock(),
                 method=RequestsMethods.PATCH,
-                json_complete=MagicMock(),
+                json_complete='{"test": "test"}',
             )
 
     def test_call_the_api_patch_no_data(self):
         with self.assertRaises(Exception):
             self.api.call_the_api(api_call=MagicMock(), method=RequestsMethods.PATCH)
 
-    @patch("urllib3.PoolManager")
-    def test_call_the_api_delete_valid(self, pool_mock):
-        pool_mock.return_value.request.return_value.data = (
-            b'{"message": "Deletion successful"}'
+    @patch("httpx.Client")
+    def test_call_the_api_delete_valid(self, httpx_client_mock):
+        httpx_client_mock.return_value.request.return_value.text = (
+            '{"message": "Deletion successful"}'
         )
 
         self.assertEqual(
@@ -150,83 +166,83 @@ class ApiTestCase(TestCase):
 
     def test_check_the_api_call_response(self):
         mock: Mock = Mock()
-        mock.data = b'{"test": "test"}'
+        mock.text = '{"test": "test"}'
 
         self.assertEqual(
             dict({"test": "test"}),
-            self.api._Api__check_the_api_call_response(response=mock),
+            self.api._check_the_api_call_response(response=mock),
         )
 
     def test_check_the_api_call_response_no_error_message(self):
         mock: Mock = Mock()
-        mock.data = b'{"message": "test"}'
+        mock.text = '{"message": "test"}'
 
         self.assertEqual(
             dict({"message": "test"}),
-            self.api._Api__check_the_api_call_response(response=mock),
+            self.api._check_the_api_call_response(response=mock),
         )
 
     def test_check_the_api_call_response_no_json_response_value(self):
         mock: Mock = Mock()
-        mock.data = b"test"
+        mock.text = "test"
 
         self.assertEqual(
-            b"test", self.api._Api__check_the_api_call_response(response=mock).data
+            "test", self.api._check_the_api_call_response(response=mock).text
         )
 
     def test_check_the_api_call_response_exception(self):
         mock: Mock = Mock()
-        mock.data = b'{"message": "invalid API key"}'
+        mock.text = '{"message": "invalid API key"}'
 
-        with self.assertRaises(exceptions.ProtocolError):
-            self.api._Api__check_the_api_call_response(response=mock)
+        with self.assertRaises(ConnectError):
+            self.api._check_the_api_call_response(response=mock)
 
-    @patch("grafana_api.api.Api._Api__check_if_valid_json")
+    @patch("grafana_api.api.Api._check_if_valid_json")
     def test_check_the_api_call_response_valid_json(self, check_if_valid_json_mock):
         check_if_valid_json_mock.return_value = True
 
         mock: Mock = Mock()
-        mock.data = b"{}"
+        mock.text = "{}"
 
-        self.assertEqual({}, self.api._Api__check_the_api_call_response(response=mock))
+        self.assertEqual({}, self.api._check_the_api_call_response(response=mock))
 
-    @patch("grafana_api.api.Api._Api__check_if_valid_json")
+    @patch("grafana_api.api.Api._check_if_valid_json")
     def test_check_the_api_call_response_no_valid_json_status_code_result(
         self, check_if_valid_json_mock
     ):
         check_if_valid_json_mock.return_value = False
 
         mock: Mock = Mock()
-        mock.data = b""
-        mock.status = 200
+        mock.text = ""
+        mock.status_code = 200
 
         self.assertEqual(
             dict({"status": 200, "data": ""}),
-            self.api._Api__check_the_api_call_response(
+            self.api._check_the_api_call_response(
                 response=mock, response_status_code=True
             ),
         )
 
     def test_check_the_api_call_response_return_status_code_dict(self):
         mock: Mock = Mock()
-        mock.data = b'{"test": "test"}'
-        mock.status = 200
+        mock.text = '{"test": "test"}'
+        mock.status_code = 200
 
         self.assertEqual(
             dict({"status": 200, "test": "test"}),
-            self.api._Api__check_the_api_call_response(
+            self.api._check_the_api_call_response(
                 response=mock, response_status_code=True
             ),
         )
 
     def test_check_the_api_call_response_return_status_code_list(self):
         mock: Mock = Mock()
-        mock.data = b'[{"test": "test"}, {"test": "test"}]'
-        mock.status = 200
+        mock.text = b'[{"test": "test"}, {"test": "test"}]'
+        mock.status_code = 200
 
         self.assertEqual(
             list([{"status": 200, "test": "test"}, {"test": "test"}]),
-            self.api._Api__check_the_api_call_response(
+            self.api._check_the_api_call_response(
                 response=mock, response_status_code=True
             ),
         )
@@ -236,3 +252,140 @@ class ApiTestCase(TestCase):
 
     def test_prepare_api_string_no_real_value(self):
         self.assertEqual("", self.api.prepare_api_string(""))
+
+
+def test_call_the_api_http2_no_valid_method():
+    model: APIModel = APIModel(
+        host="https://test.com", token="test", http2_support=True
+    )
+    api: Api = Api(model)
+
+    with pytest.raises(Exception):
+        api.call_the_api(api_call=MagicMock(), method=MagicMock())
+
+
+def test_call_the_api_http2_get(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(text='{"status": "success"}')
+
+    model: APIModel = APIModel(
+        host="https://test.com", token="test", http2_support=True
+    )
+    api: Api = Api(model)
+
+    assert api.call_the_api(api_call="/test")["status"] == "success"
+
+
+def test_call_the_api_http2_get_error(httpx_mock: HTTPXMock):
+    httpx_mock.add_exception(ConnectError("Test"))
+
+    model: APIModel = APIModel(
+        host="https://test.com", token="test", http2_support=True
+    )
+    api: Api = Api(model)
+
+    with pytest.raises(ConnectError):
+        api.call_the_api(api_call="/test")
+
+
+def test_call_the_api_http2_put(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(text='{"status": "success"}')
+
+    model: APIModel = APIModel(
+        host="https://test.com", token="test", http2_support=True
+    )
+    api: Api = Api(model)
+
+    assert (
+        api.call_the_api(
+            method=RequestsMethods.PUT,
+            api_call="/test",
+            json_complete='{"test": "test"}',
+        )["status"]
+        == "success"
+    )
+
+
+def test_call_the_api_http2_put_no_json_complete():
+    model: APIModel = APIModel(
+        host="https://test.com", token="test", http2_support=True
+    )
+    api: Api = Api(model)
+
+    with pytest.raises(Exception):
+        api.call_the_api(
+            method=RequestsMethods.PUT, api_call="/test", json_complete=None
+        )
+
+
+def test_call_the_api_http2_post(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(text='{"status": "success"}')
+
+    model: APIModel = APIModel(
+        host="https://test.com", token="test", http2_support=True
+    )
+    api: Api = Api(model)
+
+    assert (
+        api.call_the_api(
+            method=RequestsMethods.POST,
+            api_call="/test",
+            json_complete='{"test": "test"}',
+        )["status"]
+        == "success"
+    )
+
+
+def test_call_the_api_http2_post_no_json_complete():
+    model: APIModel = APIModel(
+        host="https://test.com", token="test", http2_support=True
+    )
+    api: Api = Api(model)
+
+    with pytest.raises(Exception):
+        api.call_the_api(
+            method=RequestsMethods.POST, api_call="/test", json_complete=None
+        )
+
+
+def test_call_the_api_http2_patch(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(text='{"status": "success"}')
+
+    model: APIModel = APIModel(
+        host="https://test.com", token="test", http2_support=True
+    )
+    api: Api = Api(model)
+
+    assert (
+        api.call_the_api(
+            method=RequestsMethods.PATCH,
+            api_call="/test",
+            json_complete='{"test": "test"}',
+        )["status"]
+        == "success"
+    )
+
+
+def test_call_the_api_http2_patch_no_json_complete():
+    model: APIModel = APIModel(
+        host="https://test.com", token="test", http2_support=True
+    )
+    api: Api = Api(model)
+
+    with pytest.raises(Exception):
+        api.call_the_api(
+            method=RequestsMethods.PATCH, api_call="/test", json_complete=None
+        )
+
+
+def test_call_the_api_http2_delete(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(text='{"message": "Deletion successful"}')
+
+    model: APIModel = APIModel(
+        host="https://test.com", token="test", http2_support=True
+    )
+    api: Api = Api(model)
+
+    assert (
+        api.call_the_api(method=RequestsMethods.DELETE, api_call="/test")["message"]
+        == "Deletion successful"
+    )

--- a/tests/unittests/test_dashboard.py
+++ b/tests/unittests/test_dashboard.py
@@ -602,8 +602,8 @@ class DashboardTestCase(TestCase):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
         dashboard: Dashboard = Dashboard(grafana_api_model=model)
 
-        call_the_api_non_json_output_mock.return_value.status = 200
-        call_the_api_non_json_output_mock.return_value.data = "test"
+        call_the_api_non_json_output_mock.return_value.status_code = 200
+        call_the_api_non_json_output_mock.return_value.text = "test"
         self.assertEqual(
             "test",
             dashboard.calculate_dashboard_diff(

--- a/tests/unittests/test_datasource.py
+++ b/tests/unittests/test_datasource.py
@@ -344,7 +344,7 @@ class DatasourceTestCase(TestCase):
 
     @patch("grafana_api.api.Api.call_the_api")
     def test_disable_datasource_permissions_disable_not_possible(
-            self, call_the_api_mock
+        self, call_the_api_mock
     ):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
         datasource: Datasource = Datasource(grafana_api_model=model)
@@ -374,7 +374,7 @@ class DatasourceTestCase(TestCase):
 
     @patch("grafana_api.api.Api.call_the_api")
     def test_get_datasource_permissions_no_datasource_permissions_available(
-            self, call_the_api_mock
+        self, call_the_api_mock
     ):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
         datasource: Datasource = Datasource(grafana_api_model=model)
@@ -406,7 +406,7 @@ class DatasourceTestCase(TestCase):
 
     @patch("grafana_api.api.Api.call_the_api")
     def test_add_datasource_permissions_permission_add_not_possible(
-            self, call_the_api_mock
+        self, call_the_api_mock
     ):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
         datasource: Datasource = Datasource(grafana_api_model=model)
@@ -449,7 +449,9 @@ class DatasourceQueryResourceCachingTestCase(TestCase):
     @patch("grafana_api.api.Api.call_the_api")
     def test_get_datasource_cache(self, call_the_api_mock):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
-        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(grafana_api_model=model)
+        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(
+            grafana_api_model=model
+        )
 
         call_the_api_mock.return_value = dict({"dataSourceID": 1})
 
@@ -458,7 +460,9 @@ class DatasourceQueryResourceCachingTestCase(TestCase):
     @patch("grafana_api.api.Api.call_the_api")
     def test_get_datasource_cache_no_datasources(self, call_the_api_mock):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
-        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(grafana_api_model=model)
+        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(
+            grafana_api_model=model
+        )
 
         call_the_api_mock.return_value = dict()
 
@@ -468,7 +472,9 @@ class DatasourceQueryResourceCachingTestCase(TestCase):
     @patch("grafana_api.api.Api.call_the_api")
     def test_get_datasource_cache_no_valid_result(self, call_the_api_mock):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
-        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(grafana_api_model=model)
+        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(
+            grafana_api_model=model
+        )
 
         call_the_api_mock.return_value = dict()
 
@@ -478,16 +484,22 @@ class DatasourceQueryResourceCachingTestCase(TestCase):
     @patch("grafana_api.api.Api.call_the_api")
     def test_enable_datasource_cache(self, call_the_api_mock):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
-        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(grafana_api_model=model)
+        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(
+            grafana_api_model=model
+        )
 
         call_the_api_mock.return_value = dict({"dataSourceID": 1})
 
-        self.assertEqual({"dataSourceID": 1}, datasource.enable_datasource_cache("test"))
+        self.assertEqual(
+            {"dataSourceID": 1}, datasource.enable_datasource_cache("test")
+        )
 
     @patch("grafana_api.api.Api.call_the_api")
     def test_enable_datasource_cache_no_datasources(self, call_the_api_mock):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
-        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(grafana_api_model=model)
+        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(
+            grafana_api_model=model
+        )
 
         call_the_api_mock.return_value = dict()
 
@@ -497,7 +509,9 @@ class DatasourceQueryResourceCachingTestCase(TestCase):
     @patch("grafana_api.api.Api.call_the_api")
     def test_enable_datasource_cache_no_valid_result(self, call_the_api_mock):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
-        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(grafana_api_model=model)
+        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(
+            grafana_api_model=model
+        )
 
         call_the_api_mock.return_value = dict()
 
@@ -507,16 +521,22 @@ class DatasourceQueryResourceCachingTestCase(TestCase):
     @patch("grafana_api.api.Api.call_the_api")
     def test_disable_datasource_cache(self, call_the_api_mock):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
-        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(grafana_api_model=model)
+        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(
+            grafana_api_model=model
+        )
 
         call_the_api_mock.return_value = dict({"dataSourceID": 1})
 
-        self.assertEqual({"dataSourceID": 1}, datasource.disable_datasource_cache("test"))
+        self.assertEqual(
+            {"dataSourceID": 1}, datasource.disable_datasource_cache("test")
+        )
 
     @patch("grafana_api.api.Api.call_the_api")
     def test_disable_datasource_cache_no_datasources(self, call_the_api_mock):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
-        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(grafana_api_model=model)
+        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(
+            grafana_api_model=model
+        )
 
         call_the_api_mock.return_value = dict()
 
@@ -526,7 +546,9 @@ class DatasourceQueryResourceCachingTestCase(TestCase):
     @patch("grafana_api.api.Api.call_the_api")
     def test_disable_datasource_cache_no_valid_result(self, call_the_api_mock):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
-        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(grafana_api_model=model)
+        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(
+            grafana_api_model=model
+        )
 
         call_the_api_mock.return_value = dict()
 
@@ -536,7 +558,9 @@ class DatasourceQueryResourceCachingTestCase(TestCase):
     @patch("grafana_api.api.Api.call_the_api")
     def test_clean_datasource_cache(self, call_the_api_mock):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
-        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(grafana_api_model=model)
+        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(
+            grafana_api_model=model
+        )
 
         call_the_api_mock.return_value = dict({"dataSourceID": 1})
 
@@ -545,7 +569,9 @@ class DatasourceQueryResourceCachingTestCase(TestCase):
     @patch("grafana_api.api.Api.call_the_api")
     def test_clean_datasource_cache_no_datasources(self, call_the_api_mock):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
-        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(grafana_api_model=model)
+        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(
+            grafana_api_model=model
+        )
 
         call_the_api_mock.return_value = dict()
 
@@ -555,7 +581,9 @@ class DatasourceQueryResourceCachingTestCase(TestCase):
     @patch("grafana_api.api.Api.call_the_api")
     def test_clean_datasource_cache_no_valid_result(self, call_the_api_mock):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
-        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(grafana_api_model=model)
+        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(
+            grafana_api_model=model
+        )
 
         call_the_api_mock.return_value = dict()
 
@@ -565,18 +593,31 @@ class DatasourceQueryResourceCachingTestCase(TestCase):
     @patch("grafana_api.api.Api.call_the_api")
     def test_update_datasource_cache(self, call_the_api_mock):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
-        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(grafana_api_model=model)
-        datasource_cache: DatasourceCache = DatasourceCache(1, "test1", True, False, 12, 14)
+        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(
+            grafana_api_model=model
+        )
+        datasource_cache: DatasourceCache = DatasourceCache(
+            1, "test1", True, False, 12, 14
+        )
 
         call_the_api_mock.return_value = dict({"dataSourceID": 2})
 
-        self.assertEqual({"dataSourceID": 2}, datasource.update_datasource_cache("test", datasource_cache))
+        self.assertEqual(
+            {"dataSourceID": 2},
+            datasource.update_datasource_cache("test", datasource_cache),
+        )
 
     @patch("grafana_api.api.Api.call_the_api")
-    def test_update_datasource_cache_no_valid_datasource_cache_object(self, call_the_api_mock):
+    def test_update_datasource_cache_no_valid_datasource_cache_object(
+        self, call_the_api_mock
+    ):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
-        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(grafana_api_model=model)
-        datasource_cache: DatasourceCache = DatasourceCache(0, "test1", True, False, 12, 14)
+        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(
+            grafana_api_model=model
+        )
+        datasource_cache: DatasourceCache = DatasourceCache(
+            0, "test1", True, False, 12, 14
+        )
 
         call_the_api_mock.return_value = dict()
 
@@ -586,8 +627,12 @@ class DatasourceQueryResourceCachingTestCase(TestCase):
     @patch("grafana_api.api.Api.call_the_api")
     def test_update_datasource_cache_no_valid_result(self, call_the_api_mock):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
-        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(grafana_api_model=model)
-        datasource_cache: DatasourceCache = DatasourceCache(1, "test1", True, False, 12, 14)
+        datasource: DatasourceQueryResourceCaching = DatasourceQueryResourceCaching(
+            grafana_api_model=model
+        )
+        datasource_cache: DatasourceCache = DatasourceCache(
+            1, "test1", True, False, 12, 14
+        )
 
         call_the_api_mock.return_value = dict()
 

--- a/tests/unittests/test_folder.py
+++ b/tests/unittests/test_folder.py
@@ -187,7 +187,7 @@ class FolderTestCase(TestCase):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
         folder: Folder = Folder(grafana_api_model=model)
 
-        call_the_api_mock.return_value.status = 200
+        call_the_api_mock.return_value.status_code = 200
 
         self.assertEqual(None, folder.delete_folder("test"))
 
@@ -196,7 +196,7 @@ class FolderTestCase(TestCase):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
         folder: Folder = Folder(grafana_api_model=model)
 
-        call_the_api_mock.return_value.status = 404
+        call_the_api_mock.return_value.status_code = 404
 
         with self.assertRaises(ValueError):
             folder.delete_folder("")
@@ -206,7 +206,7 @@ class FolderTestCase(TestCase):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
         folder: Folder = Folder(grafana_api_model=model)
 
-        call_the_api_mock.return_value.status = 404
+        call_the_api_mock.return_value.status_code = 404
 
         with self.assertRaises(Exception):
             folder.delete_folder("test")

--- a/tests/unittests/test_legacy_alerting.py
+++ b/tests/unittests/test_legacy_alerting.py
@@ -85,10 +85,16 @@ class LegacyAlertingTestCase(TestCase):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
         alerting: Alerting = Alerting(grafana_api_model=model)
 
-        call_the_api_mock.return_value = dict({"Id": "test", "PanelId": 112, "NewStateDate": "2022-06-17T09:34:08Z"})
+        call_the_api_mock.return_value = dict(
+            {"Id": "test", "PanelId": 112, "NewStateDate": "2022-06-17T09:34:08Z"}
+        )
 
-        self.assertEqual(dict({"id": "test", "panelId": 112, "newStateDate": "2022-06-17T09:34:08Z"}),
-                         alerting.get_alert_by_id(1))
+        self.assertEqual(
+            dict(
+                {"id": "test", "panelId": 112, "newStateDate": "2022-06-17T09:34:08Z"}
+            ),
+            alerting.get_alert_by_id(1),
+        )
 
     def test_get_alert_by_id_no_id(self):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())

--- a/tests/unittests/test_legacy_playlist.py
+++ b/tests/unittests/test_legacy_playlist.py
@@ -158,7 +158,7 @@ class LegacyPlaylistTestCase(TestCase):
         )
         playlist: LegacyPlaylist = LegacyPlaylist(grafana_api_model=model)
 
-        call_the_api_mock.return_value.status = 400
+        call_the_api_mock.return_value.status_code = 400
 
         with self.assertRaises(ValueError):
             playlist.delete_playlist(0)
@@ -168,7 +168,7 @@ class LegacyPlaylistTestCase(TestCase):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
         playlist: LegacyPlaylist = LegacyPlaylist(grafana_api_model=model)
 
-        call_the_api_mock.return_value.status = 400
+        call_the_api_mock.return_value.status_code = 400
 
         with self.assertRaises(Exception):
             playlist.delete_playlist(1)

--- a/tests/unittests/test_licensing.py
+++ b/tests/unittests/test_licensing.py
@@ -11,8 +11,8 @@ class LicenseTestCase(TestCase):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
         licensing: Licensing = Licensing(grafana_api_model=model)
 
-        call_the_api_mock.return_value.status = 200
-        call_the_api_mock.return_value.data = b"true"
+        call_the_api_mock.return_value.status_code = 200
+        call_the_api_mock.return_value.text = "true"
 
         self.assertEqual(True, licensing.check_license_availability())
 
@@ -21,7 +21,7 @@ class LicenseTestCase(TestCase):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
         licensing: Licensing = Licensing(grafana_api_model=model)
 
-        call_the_api_mock.return_value.status = 400
+        call_the_api_mock.return_value.status_code = 400
 
         with self.assertRaises(Exception):
             licensing.check_license_availability()

--- a/tests/unittests/test_other_http.py
+++ b/tests/unittests/test_other_http.py
@@ -1,6 +1,9 @@
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+from pytest_httpx import HTTPXMock
+from httpx import ConnectError
+
 from grafana_api.model import APIModel
 from grafana_api.other_http import OtherHTTP
 
@@ -50,40 +53,109 @@ class OtherHTTPTestCase(TestCase):
         with self.assertRaises(Exception):
             other_http.renew_login_session_based_on_remember_cookie()
 
-    @patch("urllib3.PoolManager")
-    def test_get_health_status(self, pool_mock):
+    @patch("httpx.Client")
+    def test_get_health_status(self, httpx_client_mock):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
         other_http: OtherHTTP = OtherHTTP(grafana_api_model=model)
 
-        pool_mock.return_value.request.return_value.data = b'{"commit": "087143285"}'
+        httpx_client_mock.return_value.request.return_value.text = (
+            '{"commit": "087143285"}'
+        )
 
         self.assertEqual(dict({"commit": "087143285"}), other_http.get_health_status())
 
-    @patch("urllib3.PoolManager")
-    def test_get_health_status_no_valid_result(self, pool_mock):
+    @patch("httpx.Client")
+    def test_get_health_status_no_valid_result(self, httpx_client_mock):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
         other_http: OtherHTTP = OtherHTTP(grafana_api_model=model)
 
-        pool_mock.return_value.request.return_value.data = b"{}"
+        httpx_client_mock.return_value.request.return_value.text = "{}"
 
         with self.assertRaises(Exception):
             other_http.get_health_status()
 
-    @patch("urllib3.PoolManager")
-    def test_get_metrics(self, pool_mock):
+    @patch("httpx.Client")
+    def test_get_metrics(self, httpx_client_mock):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
         other_http: OtherHTTP = OtherHTTP(grafana_api_model=model)
 
-        pool_mock.return_value.request.return_value.data = b"test"
+        httpx_client_mock.return_value.request.return_value.text = "test"
 
         self.assertEqual("test", other_http.get_metrics())
 
-    @patch("urllib3.PoolManager")
-    def test_get_metrics_no_valid_result(self, pool_mock):
+    @patch("httpx.Client")
+    def test_get_metrics_basic_auth(self, httpx_client_mock):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
         other_http: OtherHTTP = OtherHTTP(grafana_api_model=model)
 
-        pool_mock.return_value.request.return_value.data = b""
+        httpx_client_mock.return_value.request.return_value.text = "test"
+
+        self.assertEqual("test", other_http.get_metrics("test", "test"))
+
+    @patch("httpx.Client")
+    def test_get_metrics_request_issue(self, httpx_client_mock):
+        model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
+        other_http: OtherHTTP = OtherHTTP(grafana_api_model=model)
+
+        httpx_client_mock.return_value.request.side_effect = ConnectError("Test")
+
+        with self.assertRaises(ConnectError):
+            other_http.get_metrics()
+
+    @patch("httpx.Client")
+    def test_get_metrics_no_valid_result(self, httpx_client_mock):
+        model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
+        other_http: OtherHTTP = OtherHTTP(grafana_api_model=model)
+
+        httpx_client_mock.return_value.request.return_value.text = ""
 
         with self.assertRaises(Exception):
             other_http.get_metrics()
+
+    @patch("httpx.Client")
+    def test_get_plugin_metrics(self, httpx_client_mock):
+        model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
+        other_http: OtherHTTP = OtherHTTP(grafana_api_model=model)
+
+        httpx_client_mock.return_value.request.return_value.text = "test"
+
+        self.assertEqual("test", other_http.get_plugin_metrics("test"))
+
+    @patch("httpx.Client")
+    def test_get_plugin_metrics_basic_auth(self, httpx_client_mock):
+        model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
+        other_http: OtherHTTP = OtherHTTP(grafana_api_model=model)
+
+        httpx_client_mock.return_value.request.return_value.text = "test"
+
+        self.assertEqual("test", other_http.get_plugin_metrics("test", "test", "test"))
+
+    @patch("httpx.Client")
+    def test_get_plugin_metrics_no_plugin_id(self, httpx_client_mock):
+        model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
+        other_http: OtherHTTP = OtherHTTP(grafana_api_model=model)
+
+        httpx_client_mock.return_value.request.return_value.text = ""
+
+        with self.assertRaises(ValueError):
+            other_http.get_plugin_metrics("")
+
+    @patch("httpx.Client")
+    def test_get_plugin_metrics_no_valid_result(self, httpx_client_mock):
+        model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
+        other_http: OtherHTTP = OtherHTTP(grafana_api_model=model)
+
+        httpx_client_mock.return_value.request.return_value.text = ""
+
+        with self.assertRaises(Exception):
+            other_http.get_plugin_metrics("test")
+
+
+def test_get_plugin_metrics_http2_support(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(text="test")
+    model: APIModel = APIModel(
+        host="https://test.com", token="test", http2_support=True
+    )
+    other_http: OtherHTTP = OtherHTTP(grafana_api_model=model)
+
+    assert other_http.get_plugin_metrics("test") == "test"

--- a/tests/unittests/test_playlist.py
+++ b/tests/unittests/test_playlist.py
@@ -249,7 +249,7 @@ class PlaylistTestCase(TestCase):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
         playlist: Playlist = Playlist(grafana_api_model=model)
 
-        call_the_api_mock.return_value.status = 200
+        call_the_api_mock.return_value.status_code = 200
 
         self.assertEqual(None, playlist.delete_playlist("test"))
 
@@ -260,7 +260,7 @@ class PlaylistTestCase(TestCase):
         )
         playlist: Playlist = Playlist(grafana_api_model=model)
 
-        call_the_api_mock.return_value.status = 400
+        call_the_api_mock.return_value.status_code = 400
 
         with self.assertRaises(ValueError):
             playlist.delete_playlist("")
@@ -270,7 +270,7 @@ class PlaylistTestCase(TestCase):
         model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
         playlist: Playlist = Playlist(grafana_api_model=model)
 
-        call_the_api_mock.return_value.status = 400
+        call_the_api_mock.return_value.status_code = 400
 
         with self.assertRaises(Exception):
             playlist.delete_playlist("test")


### PR DESCRIPTION
**TODO:** 
- [x] Adjust the other API endpoint and the tests to support non auth for this dedicated endpoint
- [x] Fix the unittests
- [x] Fix the integrationtests
- [x] Create a new proxy to support HTTP/2
- [x] Adjust the unittests to support HTTP/2
- [x] Adjust the Integrationtest to support HTTP/2
- [x] Identify the issue why `httpx` use HTTP/1.1 instead of HTTP/2 inside the integration test case.
- [x] Document the general HTTP/2 support
- [x] Document the HTTP/2 custom ssl_context support