### PR TITLE
feat: Add extra headers on APIModel

### DIFF
--- a/docs/content/grafana_api/model.md
+++ b/docs/content/grafana_api/model.md
@@ -85,6 +85,7 @@ The class includes all necessary variables to establish a connection to the Graf
 - `username` _str_ - Specify the username of the Grafana system
 - `password` _str_ - Specify the password of the Grafana system
 - `timeout` _float_ - Specify the timeout of the Grafana system
+- `headers` _dict_ - Specify the headers of the Grafana system
 - `http2_support` _bool_ - Specify if you want to use HTTP/2
 - `ssl_context` _ssl.SSLContext_ - Specify the custom ssl context of the Grafana system
 - `num_pools` _int_ - Specify the number of the connection pool

--- a/grafana_api/api.py
+++ b/grafana_api/api.py
@@ -50,7 +50,12 @@ class Api:
         """
 
         api_url: str = f"{self.grafana_api_model.host}{api_call}"
-        headers: dict = dict(
+
+        headers: dict = dict()
+        if self.grafana_api_model.headers is not None:
+            headers: dict = self.grafana_api_model.headers
+
+        headers.update(
             {"Authorization": f"Bearer {self.grafana_api_model.token}"},
         )
 

--- a/grafana_api/model.py
+++ b/grafana_api/model.py
@@ -85,6 +85,7 @@ class APIModel:
         username (str): Specify the username of the Grafana system
         password (str): Specify the password of the Grafana system
         timeout (float): Specify the timeout of the Grafana system
+        headers (dict): Specify the headers of the Grafana system
         http2_support (bool): Specify if you want to use HTTP/2
         ssl_context (ssl.SSLContext): Specify the custom ssl context of the Grafana system
         num_pools (int): Specify the number of the connection pool
@@ -95,6 +96,7 @@ class APIModel:
     token: str = None
     username: str = None
     password: str = None
+    headers: dict = None
     timeout: float = 10.0
     http2_support: bool = False
     ssl_context: ssl.SSLContext = httpx.create_ssl_context(http2=http2_support)

--- a/tests/unittests/test_api.py
+++ b/tests/unittests/test_api.py
@@ -36,6 +36,57 @@ class ApiTestCase(TestCase):
         )
 
     @patch("httpx.Client")
+    def test_call_the_api_with_headers(self):
+        mock_client = MagicMock(spec=Client)
+        mock_client.request.return_value.text = '{"status": "success"}'
+        self.api.create_the_http_api_client = MagicMock(return_value=mock_client)
+
+        headers = {"X-Custom-Header": "custom_value"}
+        response = self.api.call_the_api(
+            api_call=MagicMock(),
+            method=RequestsMethods.GET,
+            headers=headers,
+        )
+
+        mock_client.request.assert_called_with(
+            method="GET",
+            url=MagicMock(),
+            headers={
+                "Authorization": f"Bearer {self.model.token}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "X-Custom-Header": "custom_value",
+            },
+            json=None,
+            timeout=self.model.timeout,
+        )
+        self.assertEqual(response, {"status": "success"})
+
+    @patch("httpx.Client")
+    def test_call_the_api_with_no_headers(self):
+        mock_client = MagicMock(spec=Client)
+        mock_client.request.return_value.text = '{"status": "success"}'
+        self.api.create_the_http_api_client = MagicMock(return_value=mock_client)
+
+        response = self.api.call_the_api(
+            api_call=MagicMock(),
+            method=RequestsMethods.GET,
+        )
+
+        mock_client.request.assert_called_with(
+            method="GET",
+            url=MagicMock(),
+            headers={
+                "Authorization": f"Bearer {self.model.token}",
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+            },
+            json=None,
+            timeout=self.model.timeout,
+        )
+        self.assertEqual(response, {"status": "success"})
+
+    @patch("httpx.Client")
     def test_call_the_api_org_id(self, httpx_client_mock):
         httpx_client_mock.return_value.request.return_value.text = (
             '{"status": "success"}'


### PR DESCRIPTION
Add capability to provide extra headers when connecting to a Grafana that have a Front Proxy that requires extra headers on the requests.