### PR TITLE
Fix: folderIds=0 at get_all_folder_ids_and_names

### DIFF
--- a/grafana_api/folder.py
+++ b/grafana_api/folder.py
@@ -399,7 +399,7 @@ class Folder:
         """
 
         folders_raw: list = Api(self.grafana_api_model).call_the_api(
-            f"{APIEndpoints.SEARCH.value}?folderIds=0"
+            f"{APIEndpoints.SEARCH.value}?folderIds=null"
         )
         folders_raw_len: int = len(folders_raw)
         folders: list = list()


### PR DESCRIPTION
Fixes https://github.com/ZPascal/grafana_api_sdk/issues/125 by simple way.
The `folderIds=0` must be replaced to `folderIds=null`
Issue was intruduced with Grafana 12. Fix is tested with Grafana 11 and 12.

Grafana 12 may use different (version of) CLI parameter parser, which puts the `0` as an item of `FolderIds`, but the null keeps the `FolderIds` list empty, see in Grafana source code:
```
FolderIds []int64 `json:"folderIds"`
```
https://github.com/grafana/grafana/blob/60df44bb2366fa79808dda46bb2657a2a1646307/pkg/services/dashboards/database/database.go#L921
```
  if len(query.FolderIds) > 0 {
    filters = append(filters, searchstore.FolderFilter{IDs: query.FolderIds})
  }
````