### PR TITLE
feat(contact-point): support retrieval by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ In general, my focus on this project is to implement and deliver old and new fea
 - Update ethe interval fo the alert rule group
 - Delete alert rule
 - Get all contact points
+- Get contact point by name
 - Add contact point
 - Update contact point
 - Delete contact point

--- a/grafana_api/alerting_provisioning.py
+++ b/grafana_api/alerting_provisioning.py
@@ -226,6 +226,30 @@ class AlertingProvisioning:
         else:
             return api_call
 
+    def get_contact_point(self, name: str) -> list:
+        """Return contact points that exactly match the given name.
+
+        This method does not support partial matching — the `name` value must
+        match exactly.
+
+        Raises:
+            Exception: If an unspecified error occurs during the API call.
+
+        Returns:
+            list: A list of contact points whose `name` property exactly matches
+            the provided `name`.
+        """
+
+        api_call: list = Api(self.grafana_api_model).call_the_api(
+            f"{APIEndpoints.ALERTING_PROVISIONING.value}/contact-points?name={name}"
+        )
+
+        if api_call == list():
+            logging.error(f"Check the error: {api_call}.")
+            raise Exception
+        else:
+            return api_call
+
     def add_contact_point(
         self,
         embedded_contact_point: EmbeddedContactPoint,

--- a/grafana_api/alerting_provisioning.py
+++ b/grafana_api/alerting_provisioning.py
@@ -244,11 +244,7 @@ class AlertingProvisioning:
             f"{APIEndpoints.ALERTING_PROVISIONING.value}/contact-points?name={name}"
         )
 
-        if api_call == list():
-            logging.error(f"Check the error: {api_call}.")
-            raise Exception
-        else:
-            return api_call
+        return api_call
 
     def add_contact_point(
         self,

--- a/grafana_api/alerting_provisioning.py
+++ b/grafana_api/alerting_provisioning.py
@@ -244,6 +244,10 @@ class AlertingProvisioning:
             f"{APIEndpoints.ALERTING_PROVISIONING.value}/contact-points?name={name}"
         )
 
+        if not isinstance(api_call, list):
+            logging.error(f"Check the error: {api_call}.")
+            raise Exception
+
         return api_call
 
     def add_contact_point(

--- a/tests/integrationtest/test_alerting_provisioning.py
+++ b/tests/integrationtest/test_alerting_provisioning.py
@@ -126,6 +126,12 @@ class AlertingProvisioningTest(TestCase):
             "test1", self.alerting_provisioning.get_all_contact_points()[1].get("name")
         )
 
+    def test_j_get_specific_contact_points(self):
+        self.assertEqual(
+            "email receiver",
+            self.alerting_provisioning.get_contact_point("email receiver")[0],
+        )
+
     def test_j_get_notification_policies(self):
         self.assertEqual(
             "grafana-default-email",

--- a/tests/unittests/test_alerting_provisioning.py
+++ b/tests/unittests/test_alerting_provisioning.py
@@ -223,11 +223,39 @@ class AlertingProvisioningTestCase(TestCase):
             grafana_api_model=model
         )
 
-        call_the_api_mock.return_value = list([{"test": "test"}])
+        call_the_api_mock.return_value = list([{"test": "test"}, {"specific-contact-point": "specific contact point"}])
 
         self.assertEqual(
-            list([{"test": "test"}]),
+            list([{"test": "test"}, {"specific-contact-point": "specific contact point"}]),
             alerting_provisioning.get_all_contact_points(),
+        )
+
+    @patch("grafana_api.api.Api.call_the_api")
+    def test_get_specific_contact_points(self, call_the_api_mock):
+        model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
+        alerting_provisioning: AlertingProvisioning = AlertingProvisioning(
+            grafana_api_model=model
+        )
+
+        call_the_api_mock.return_value = list([{"specific-contact-point": "specific contact point"}])
+
+        self.assertEqual(
+            list([{"specific-contact-point": "specific contact point"}]),
+            alerting_provisioning.get_contact_point("specific-contact-point"),
+        )
+
+    @patch("grafana_api.api.Api.call_the_api")
+    def test_get_specific_contact_points_empty_on_partial_name_should_return_empty_list(self, call_the_api_mock):
+        model: APIModel = APIModel(host=MagicMock(), token=MagicMock())
+        alerting_provisioning: AlertingProvisioning = AlertingProvisioning(
+            grafana_api_model=model
+        )
+
+        call_the_api_mock.return_value = list([])
+
+        self.assertEqual(
+            list([]),
+            alerting_provisioning.get_contact_point("contact-point-invalid-name"),
         )
 
     @patch("grafana_api.api.Api.call_the_api")


### PR DESCRIPTION
- Adds support for retrieving a contact point by its exact name.
- If multiple contact points share the same name, the method will return all matching contact points in a list.
- This can occur, for example, when an alert rule uses contact points that implement multiple actions. In Grafana’s UI, such contact points are grouped by name, but they are stored as separate contact points in the backend.

